### PR TITLE
fix backward compatibility for SHARED_TARGET constant dict in shared_setup

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -145,7 +145,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.10.1'
+VERSION = '0.10.2'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 
@@ -1335,6 +1335,10 @@ class vsc_setup(object):
         x = self.parse_target(target, urltemplate)
 
         setupfn(**x)
+
+
+# here for backwards compatibility
+SHARED_TARGET = vsc_setup.SHARED_TARGET
 
 
 def action_target(package):


### PR DESCRIPTION
older versions of vsc packages (incl. vsc-base) used something like this in `setup.py`:

```python
import vsc.install.shared_setup as shared_setup
shared_setup.SHARED_TARGET.update({
    'url': 'https://github.com/hpcugent/vsc-base',
    'download_url': 'https://github.com/hpcugent/vsc-base'
})
```

This got broken by the cleanup in #34, where `SHARED_TARGET` was moved into the `vsc_setup` class.