### PR TITLE
Fix rpm exclude pkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@ Description
 ===========
 vsc-install provides shared setuptools functions and classes for python libraries developed by UGent's HPC group
 
+Common pitfalls
+=========
+bdist_rpm will fail if your install_requires = 'setuptools' because it will fail to find a setuptools rpm.
+```
+export VSC_RPM_PYTHON=1
+```
+will make sure the `python-` prefix is added to the packages in install_requires for building RPM's so python-setuptools will be used.
+
 Add tests
 =========
 

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1375,9 +1375,11 @@ if __name__ == '__main__':
         'version': VERSION,
         'author': [sdw, ag, jt],
         'maintainer': [sdw, ag, jt],
-        'excluded_pkgs_rpm': [],  # vsc-install ships vsc package (the vsc package is removed by default)
         'install_requires': install_requires,
-        'setup_requires': 'setuptools',
+        'setup_requires': [
+            'setuptools',
+        ],
+        'excluded_pkgs_rpm': [],  # vsc-install ships vsc package (the vsc package is removed by default)
     }
 
     action_target(PACKAGE)

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1358,6 +1358,9 @@ if __name__ == '__main__':
     """
     This main is the setup.py for vsc-install
     """
+    install_requires = [
+        'setuptools',
+    ]
     if sys.version_info < (2, 7):
         # py26 support dropped in 0.8, and the old versions don't detect enough
         log.info('no prospector support in py26 (or older)')
@@ -1373,6 +1376,7 @@ if __name__ == '__main__':
         'author': [sdw, ag, jt],
         'maintainer': [sdw, ag, jt],
         'excluded_pkgs_rpm': [],  # vsc-install ships vsc package (the vsc package is removed by default)
+        'install_requires': install_requires,
         'setup_requires': 'setuptools',
     }
 

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -918,7 +918,9 @@ class vsc_setup(object):
             extra is a list of packages added to the discovered ones
             exclude is list of regex patterns to filter the packages
         """
-        res = vsc_setup.add_and_remove(self.package_files['packages'].keys(), extra=extra, exclude=exclude)
+        packages = self.package_files['packages'].keys()
+        log.info('initial packages list: %s' % packages)
+        res = vsc_setup.add_and_remove(packages, extra=extra, exclude=exclude)
         log.info('generated packages list: %s' % res)
         return res
 
@@ -1306,7 +1308,9 @@ class vsc_setup(object):
 
         # Add (default) and excluded_pkgs_rpm packages to SHARED_TARGET
         # the default ones are only the ones with a __init__.py file
-        vsc_setup.SHARED_TARGET['packages'] = self.generate_packages(extra=pkgs)
+        # therefor we regenerate self.package files with the excluded pkgs as extra param
+        self.package_files = self.files_in_packages(excluded_pkgs=pkgs)
+        vsc_setup.SHARED_TARGET['packages'] = self.generate_packages()
         self.build_setup_cfg_for_bdist_rpm(target)
 
     def action_target(self, target, setupfn=setup, extra_sdist=None, urltemplate=None):
@@ -1369,6 +1373,7 @@ if __name__ == '__main__':
         'author': [sdw, ag, jt],
         'maintainer': [sdw, ag, jt],
         'excluded_pkgs_rpm': [],  # vsc-install ships vsc package (the vsc package is removed by default)
+        'setup_requires': 'setuptools',
     }
 
     action_target(PACKAGE)

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -145,7 +145,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.10.5'
+VERSION = '0.10.6'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1304,8 +1304,9 @@ class vsc_setup(object):
         if pkgs is not None:
             getattr(__builtin__, '__target')['excluded_pkgs_rpm'] = pkgs
 
-        # Add (default) packages to SHARED_TARGET
-        vsc_setup.SHARED_TARGET['packages'] = self.generate_packages()
+        # Add (default) and excluded_pkgs_rpm packages to SHARED_TARGET
+        # the default ones are only the ones with a __init__.py file
+        vsc_setup.SHARED_TARGET['packages'] = self.generate_packages(extra=pkgs)
         self.build_setup_cfg_for_bdist_rpm(target)
 
     def action_target(self, target, setupfn=setup, extra_sdist=None, urltemplate=None):
@@ -1353,9 +1354,6 @@ if __name__ == '__main__':
     """
     This main is the setup.py for vsc-install
     """
-    install_requires = [
-        'setuptools',
-    ]
     if sys.version_info < (2, 7):
         # py26 support dropped in 0.8, and the old versions don't detect enough
         log.info('no prospector support in py26 (or older)')
@@ -1370,10 +1368,6 @@ if __name__ == '__main__':
         'version': VERSION,
         'author': [sdw, ag, jt],
         'maintainer': [sdw, ag, jt],
-        'install_requires': install_requires,
-        'setup_requires': [
-            'setuptools',
-        ],
         'excluded_pkgs_rpm': [],  # vsc-install ships vsc package (the vsc package is removed by default)
     }
 

--- a/test/shared_setup.py
+++ b/test/shared_setup.py
@@ -154,11 +154,18 @@ class TestSetup(TestCase):
             'name': 'vsc-test',
             'excluded_pkgs_rpm': [],
         }
-        self.setup.prepare_rpm(package)
-        self.assertEqual(vsc_setup.SHARED_TARGET['packages'], [])
+        setup = vsc_setup()
+
+
+        libdir  = os.path.join(os.path.dirname(os.path.realpath(__file__)), './testdata')
+        setup.REPO_LIB_DIR = libdir
+        setup.prepare_rpm(package)
+        self.assertEqual(setup.SHARED_TARGET['packages'], ['vsc', 'vsc.test'])
         package = {
             'name': 'vsc-test',
-            'excluded_pkgs_rpm': ['vsc', 'test'],
+            'excluded_pkgs_rpm': ['vsc', 'vsc.test'],
         }
-        self.setup.prepare_rpm(package)
-        self.assertEqual(vsc_setup.SHARED_TARGET['packages'], ['vsc', 'test'])
+        setup = vsc_setup()
+        setup.REPO_LIB_DIR = libdir
+        setup.prepare_rpm(package)
+        self.assertEqual(setup.SHARED_TARGET['packages'], ['vsc', 'vsc.test'])

--- a/test/shared_setup.py
+++ b/test/shared_setup.py
@@ -144,3 +144,21 @@ class TestSetup(TestCase):
         self.mock_stdout(False)
         self.assertTrue(re.search(r"^args:\s*\(\)", txt, re.M))
         self.assertTrue(re.search(r"^kwargs:\s*\{.*'url':\s*'http://example.com/vsc-test'", txt, re.M))
+
+    def test_prepare_rpm(self):
+        """
+        Test the prepare rpm function
+        especially in effect to genereting correct package list wrt excluded_pkgs_rpm
+        """
+        package = {
+            'name': 'vsc-test',
+            'excluded_pkgs_rpm': [],
+        }
+        self.setup.prepare_rpm(package)
+        self.assertEqual(vsc_setup.SHARED_TARGET['packages'], [])
+        package = {
+            'name': 'vsc-test',
+            'excluded_pkgs_rpm': ['vsc', 'test'],
+        }
+        self.setup.prepare_rpm(package)
+        self.assertEqual(vsc_setup.SHARED_TARGET['packages'], ['vsc', 'test'])

--- a/test/shared_setup.py
+++ b/test/shared_setup.py
@@ -35,7 +35,6 @@ from vsc.install.testing import TestCase
 class TestSetup(TestCase):
     """Test shared_setup"""
 
-
     def setUp(self):
         """create a self.setup.instance for every test"""
         super(TestSetup, self).setUp()
@@ -148,7 +147,7 @@ class TestSetup(TestCase):
     def test_prepare_rpm(self):
         """
         Test the prepare rpm function
-        especially in effect to genereting correct package list wrt excluded_pkgs_rpm
+        especially in effect to generating correct package list wrt excluded_pkgs_rpm
         """
         package = {
             'name': 'vsc-test',
@@ -156,8 +155,7 @@ class TestSetup(TestCase):
         }
         setup = vsc_setup()
 
-
-        libdir  = os.path.join(os.path.dirname(os.path.realpath(__file__)), './testdata')
+        libdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), './testdata')
         setup.REPO_LIB_DIR = libdir
         setup.prepare_rpm(package)
         self.assertEqual(setup.SHARED_TARGET['packages'], ['vsc', 'vsc.test'])

--- a/test/testdata/vsc/__init__.py
+++ b/test/testdata/vsc/__init__.py
@@ -1,0 +1,30 @@
+#
+# Copyright 2015-2016 Ghent University
+#
+# This file is part of vsc-install,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/hpcugent/vsc-install
+#
+# vsc-install is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Library General Public License as
+# published by the Free Software Foundation, either version 2 of
+# the License, or (at your option) any later version.
+#
+# vsc-install is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public License
+# along with vsc-install. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Allow other packages to extend this namespace, zip safe setuptools style
+"""
+import pkg_resources
+pkg_resources.declare_namespace(__name__)

--- a/test/testdata/vsc/test/__init__.py
+++ b/test/testdata/vsc/test/__init__.py
@@ -1,0 +1,30 @@
+#
+# Copyright 2015-2016 Ghent University
+#
+# This file is part of vsc-install,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/hpcugent/vsc-install
+#
+# vsc-install is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Library General Public License as
+# published by the Free Software Foundation, either version 2 of
+# the License, or (at your option) any later version.
+#
+# vsc-install is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public License
+# along with vsc-install. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Allow other packages to extend this namespace, zip safe setuptools style
+"""
+import pkg_resources
+pkg_resources.declare_namespace(__name__)


### PR DESCRIPTION
the excluded pgkgs ware never picked up when we started to cache the package_files, 
so be sure to regenerate the package files with the excluded packages as parameter, once we know it.
