### PR TITLE
commontest: add more prospector whitelist

### DIFF
--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -101,6 +101,8 @@ class CommonTest(TestCase):
         'unused-variable',
         'reimported',
         'F811',  # redefinition of unused name
+        'unused-import',
+        'syntax-error',
         #'protected-access',
         #'logging-not-lazy',
     ]

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -145,7 +145,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.10.10'
+VERSION = '0.10.11'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 


### PR DESCRIPTION
* the `syntax-error` one is typically caught by our 'import all whatever' tests, but helps to debug such failing test
* unused-import is self-explanatory