### PR TITLE
don't require vsc-install, it wont work without it anyway

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1122,7 +1122,7 @@ class vsc_setup(object):
         'command_packages': ['vsc.install.shared_setup', NEW_SHARED_SETUP, 'setuptools.command', 'distutils.command'],
         'download_url': '',
         'package_dir': {'': DEFAULT_LIB_DIR},
-        'setup_requires': ['setuptools', 'vsc-install >= %s' % VERSION],
+        'setup_requires': [],
         'test_suite': DEFAULT_TEST_SUITE,
         'url': '',
         'dependency_links': [],

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -146,7 +146,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.10.20'
+VERSION = '0.10.21'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 


### PR DESCRIPTION
requiring vsc-install will now try to install vsc-install from github, which is not always what you want? see https://github.com/hpcugent/vsc-base/issues/243