### PR TITLE
don't cleanup setup.cfg right before creating an rpm

### DIFF
--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Ghent University
+# Copyright 2015-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/fancylogger.py
+++ b/lib/vsc/fancylogger.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Ghent University
+# Copyright 2015-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -45,5 +45,5 @@ from vsc.utils.fancylogger import logToDevLog, getLogger
 
 # Deprecation tracker to syslog
 logToDevLog(True)
-getLogger().error("LEGACYVSCFANCYLOGGER from %s %s", __name__, globals().get('__file__','<nofile>'))
+getLogger().error("LEGACYVSCFANCYLOGGER from %s %s", __name__, globals().get('__file__', '<nofile>'))
 logToDevLog(False)

--- a/lib/vsc/install/__init__.py
+++ b/lib/vsc/install/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Ghent University
+# Copyright 2015-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016 Ghent University
+# Copyright 2014-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/headers.py
+++ b/lib/vsc/install/headers.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Ghent University
+# Copyright 2015-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1158,11 +1158,6 @@ class vsc_setup(object):
                 except OSError:
                     log.error("cleanup failed for %s" % d)
 
-        for fn in ('setup.cfg',):
-            ffn = prefix + fn
-            if os.path.isfile(ffn):
-                os.remove(ffn)
-
     @staticmethod
     def sanitize(name):
         """

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2011-2016 Ghent University
+# Copyright 2011-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -77,7 +77,7 @@ if not hasattr(__builtin__, '__target'):
     setattr(__builtin__, '__target', {})
 
 if not hasattr(__builtin__, '__test_filter'):
-    setattr(__builtin__, '__test_filter',  {
+    setattr(__builtin__, '__test_filter', {
         'module': None,
         'function': None,
         'allowmods': [],
@@ -1089,7 +1089,7 @@ class vsc_setup(object):
             release_url = "https://%s/repos/%s/%s/releases?access_token=$%s" % (api_url, owner, name, token_var)
 
             self._print(['# Run command below to make release on %s' % gh])
-            self._print(['curl', '--data', "'%s'" % json.dumps(api_data),  release_url])
+            self._print(['curl', '--data', "'%s'" % json.dumps(api_data), release_url])
 
         def pypi(self):
             """Register, sdist and upload to pypi"""

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -148,7 +148,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.10.21'
+VERSION = '0.10.22'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 

--- a/lib/vsc/install/testing.py
+++ b/lib/vsc/install/testing.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016 Ghent University
+# Copyright 2014-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -157,7 +157,7 @@ class TestCase(OrigTestCase):
         """
         def logmethod(*args, **kwargs):
             if hasattr(logmethod_func, 'func_name'):
-                funcname=logmethod_func.func_name
+                funcname = logmethod_func.func_name
             elif hasattr(logmethod_func, 'im_func'):
                 funcname = logmethod_func.im_func.__name__
             else:

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2016 Ghent University
+# Copyright 2016-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -25,6 +25,7 @@
 #
 #
 # don't import VSCImportTest, it will trigger the tests
+"""Commontest"""
 import vsc.install.commontest
 
 class ImportTest(vsc.install.commontest.CommonTest):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2016 Ghent University
+# Copyright 2016-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -23,4 +23,4 @@
 # You should have received a copy of the GNU Library General Public License
 # along with vsc-install. If not, see <http://www.gnu.org/licenses/>.
 #
-# Intentionally left empty
+""" Intentionally left empty"""

--- a/test/headers.py
+++ b/test/headers.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2016 Ghent University
+# Copyright 2016-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -24,6 +24,7 @@
 # along with vsc-install. If not, see <http://www.gnu.org/licenses/>.
 #
 #
+"""Test headers"""
 import glob
 import os
 

--- a/test/licenses.py
+++ b/test/licenses.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2016 Ghent University
+# Copyright 2016-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -23,6 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with vsc-install. If not, see <http://www.gnu.org/licenses/>.
 #
+"""Test licenses"""
 import os
 
 from vsc.install.testing import TestCase

--- a/test/shared_setup.py
+++ b/test/shared_setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2016 Ghent University
+# Copyright 2016-2017 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -23,6 +23,7 @@
 # You should have received a copy of the GNU Library General Public License
 # along with vsc-install. If not, see <http://www.gnu.org/licenses/>.
 #
+"""Test shared_setup"""
 import os
 import re
 


### PR DESCRIPTION
for some reason when we manually generate a setup.cfg vsc_install will remove it before a call to bdist_rpm, this doesn't sound all that smart, let's not do that.