### PR TITLE
add python-stripped-env that can be used as replacement shebang for /usr/bin/python (HPC-6427)

### DIFF
--- a/bin/python-noenv.sh
+++ b/bin/python-noenv.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-env -i /usr/bin/python "$@"
+env -i PBS_DEFAULT=$PBS_DEFAULT /usr/bin/python "$@"

--- a/bin/python-noenv.sh
+++ b/bin/python-noenv.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-env -i PBS_DEFAULT=$PBS_DEFAULT /usr/bin/python "$@"
+env -i /usr/bin/python "$@"

--- a/bin/python-stripped-env
+++ b/bin/python-stripped-env
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# -e  Exit immediately if a command exits with a non-zero status.
+# -u  Treat unset variables as an error when substituting.
+set -e -u
+
+# actual python binary that we'll call
+PYTHON=/usr/bin/python
+
+# only actually print debug info if $PYTHON_STRIPPED_ENV_DEBUG is defined
+function debug {
+    if [ ! -z ${PYTHON_STRIPPED_ENV_DEBUG:-} ]; then
+        echo "[python-stripped-env] $1"
+    fi
+}
+
+debug "which python: $(which python)"
+
+# unset all $LD_* environment variables
+for env_var in $(env | egrep '^LD_' | cut -f1 -d'='); do
+    debug "Unsetting \$$env_var (value was: ${!env_var})"
+    unset $env_var
+done
+
+debug "All \$PYTHON* environment variables that matter are ignored by using 'python -E'"
+debug "Found defined \$PYTHON* environment variables:"
+for env_var in $(env | grep '^PYTHON' | cut -f1 -d'=' | grep -v PYTHON_STRIPPED_ENV_DEBUG); do
+    debug "> \$$env_var was: ${!env_var}"
+done
+
+debug "$PYTHON -E $(echo "$@")"
+$PYTHON -E "$@"

--- a/lib/vsc/install/headers.py
+++ b/lib/vsc/install/headers.py
@@ -43,7 +43,8 @@ import re
 import sys
 
 from datetime import date
-from vsc.install.shared_setup import vsc_setup, log, SHEBANG_ENV_PYTHON, SHEBANG_NOENV_PYTHON
+from vsc.install.shared_setup import SHEBANG_ENV_PYTHON, SHEBANG_NOENV_PYTHON, SHEBANG_STRIPPED_ENV_PYTHON
+from vsc.install.shared_setup import log, vsc_setup
 
 HEADER_REGEXP = re.compile(r'\A(.*?)^(?:\'\'\'|"""|### END OF HEADER)', re.M | re.S)
 ENCODING_REGEXP = re.compile(r'^(\s*#\s*.*?coding[:=]\s*([-\w.]+).*).*$', re.M)  # PEP0263, 1st or 2nd line

--- a/lib/vsc/install/headers.py
+++ b/lib/vsc/install/headers.py
@@ -43,8 +43,7 @@ import re
 import sys
 
 from datetime import date
-from vsc.install.shared_setup import SHEBANG_ENV_PYTHON, SHEBANG_NOENV_PYTHON, SHEBANG_STRIPPED_ENV_PYTHON
-from vsc.install.shared_setup import log, vsc_setup
+from vsc.install.shared_setup import SHEBANG_ENV_PYTHON, log, vsc_setup
 
 HEADER_REGEXP = re.compile(r'\A(.*?)^(?:\'\'\'|"""|### END OF HEADER)', re.M | re.S)
 ENCODING_REGEXP = re.compile(r'^(\s*#\s*.*?coding[:=]\s*([-\w.]+).*).*$', re.M)  # PEP0263, 1st or 2nd line
@@ -188,8 +187,7 @@ def check_header(filename, script=False, write=False):
         # original position
         header_end_pos += 1 + len(shebang)  # 1 is from splitted newline
 
-        shebangs_python = (SHEBANG_ENV_PYTHON, SHEBANG_NOENV_PYTHON, SHEBANG_STRIPPED_ENV_PYTHON)
-        if 'python' in shebang and shebang not in shebangs_python:
+        if 'python' in shebang and shebang != SHEBANG_ENV_PYTHON:
             log.info('python in shebang, forcing env python (header modified)')
             changed = True
             shebang = SHEBANG_ENV_PYTHON

--- a/lib/vsc/install/headers.py
+++ b/lib/vsc/install/headers.py
@@ -188,7 +188,8 @@ def check_header(filename, script=False, write=False):
         # original position
         header_end_pos += 1 + len(shebang)  # 1 is from splitted newline
 
-        if 'python' in shebang and shebang not in (SHEBANG_ENV_PYTHON, SHEBANG_NOENV_PYTHON):
+        shebangs_python = (SHEBANG_ENV_PYTHON, SHEBANG_NOENV_PYTHON, SHEBANG_STRIPPED_ENV_PYTHON)
+        if 'python' in shebang and shebang not in shebangs_python:
             log.info('python in shebang, forcing env python (header modified)')
             changed = True
             shebang = SHEBANG_ENV_PYTHON

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -606,7 +606,7 @@ class vsc_setup(object):
                     if pyshebang_reg.search(first_line):
                         log.info("going to adapt shebang for script %s" % fn)
                         dest, code = self._recopy(base_dir, fn)
-                        code = pyshebang_reg.sub(SHEBANG_PYTHON_E, code)
+                        code = pyshebang_reg.sub(SHEBANG_STRIPPED_ENV_PYTHON, code)
                         self._write(dest, code)
             else:
                 log.info("no scripts to check for shebang")

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -165,6 +165,7 @@ PYTHON_BDIST_RPM_PREFIX_MAP = {
 SHEBANG_ENV_PYTHON = '#!/usr/bin/env python'
 SHEBANG_NOENV_PYTHON = '#!/usr/bin/python-noenv'
 SHEBANG_PYTHON_E = '#!/usr/bin/python -E'
+SHEBANG_STRIPPED_ENV_PYTHON = '#!/usr/bin/python-stripped-env'
 
 # to be inserted in sdist version of shared_setup
 NEW_SHARED_SETUP_HEADER_TEMPLATE = """

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -148,7 +148,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.10.24'
+VERSION = '0.10.25'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 


### PR DESCRIPTION
fix for faulty warning:

```
$ ml swap cluster/golett
$ qsub test.sh 
Unable to determine clustername, using default delcatty (no PBS_DEFAULT)
920763.master19.golett.gent.vsc
```