### PR TITLE
add Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+script:
+  - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ python:
   - "2.6"
   - "2.7"
 script:
+  # 'hpcugent' is a mandatory remote for setup.py to work (because of get_name_url)
+  - git remote add hpcugent https://github.com/hpcugent/vsc-install.git
   - python setup.py test


### PR DESCRIPTION
This is an easy way to check the `vsc-install` tests against Python 2.6 & 2.7 (and maybe also other Python versions soon, see #83).

We can either rely on both Jenkins & Travis, or just park this `.travis.yml` in the repository and stick to using Jenkins alone (we'll need to tell Travis to run tests before it start interfering with PRs even if a `.travis.yml` is there). Or maybe even we can consider switching to Travis alone and reduce maintenance effort on our private Jenkins instance...

Even if we stick to Jenkins-only this is still useful, since contributors can easily run the tests on Travis rather than running them locally, pretty much with the flick of a switch to enable Travis on their fork only (like I did, see https://travis-ci.org/boegel/vsc-install).
That way they can check whether tests still pass before even opening a pull request...