### PR TITLE
updates for vsc-base

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.md LICENSE
+recursive-include lib vsc * *
+recursive-include bin *
+global-exclude *.py[co]
+global-exclude __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md LICENSE
 recursive-include lib vsc * *
 recursive-include bin *
+recursive-include test *
 global-exclude *.py[co]
 global-exclude __pycache__

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1523,8 +1523,7 @@ if __name__ == '__main__':
     This main is the setup.py for vsc-install
     """
     install_requires = [
-        'setuptools',
-        'future'
+        'setuptools'
     ]
 
     PACKAGE = {

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1524,6 +1524,7 @@ if __name__ == '__main__':
     """
     install_requires = [
         'setuptools',
+        'future'
     ]
 
     PACKAGE = {


### PR DESCRIPTION
This PR will include tweaks to vsc-install that are necessary for function / packaging of vsc-base. For example, we need a MANIFEST.in for the LICENSE file to be included in the install.