### PR TITLE
tweak egg_info & sdist directly in self.cmdclass in vsc_bdist_rpm.run (HPC-7552)

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -155,7 +155,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.11.5'
+VERSION = '0.11.6'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 
@@ -706,9 +706,9 @@ class vsc_setup(object):
             log.info("vsc_bdist_rpm = %s" % (self.__dict__))
             klass = _fvs('vsc_bdist_rpm egg_info')
             # changed to allow file removal
-            klass.SHARED_TARGET['cmdclass']['egg_info'] = klass.vsc_bdist_rpm_egg_info
+            self.distribution.cmdclass['egg_info'] = klass.vsc_bdist_rpm_egg_info
             # changed to allow modification of shebangs
-            klass.SHARED_TARGET['cmdclass']['sdist'] = klass.vsc_sdist_rpm
+            self.distribution.cmdclass['sdist'] = klass.vsc_sdist_rpm
             self.run_command('egg_info')  # ensure distro name is up-to-date
             orig_bdist_rpm.run(self)
 


### PR DESCRIPTION
(fixes #94)

With old `setuptools` versions, `klass.SHARED_TARGET['cmdclass']` happens to be a *reference* to `self.cmdclass`, so changing that also changes `self.cmdclass`.

This is no longer the case in recent `setuptools` versions however, because the arguments passed to the `setup` function are being copied into a new dictionary: see https://github.com/pypa/setuptools/blob/v38.4.0/setuptools/__init__.py#L113.

Hence, `klass.SHARED_TARGET['cmdclass']` is no longer a reference to `self.cmdclass`, and any changes made to it have no effect whatsoever since `SHARED_TARGET` is only used in `parse_target`, which is used to construct the arguments for the call to the `setup` function.

This basically worked by accident I think, doesn't look like we were intentionally avoiding to use `self.cmdclass`...

~~Note: this is untested, but I expect it to work after deep diving into the `setuptools` & `distutils` code and comparing differences between `setuptools` versions 0.9.8 and 38.4.0...~~
Verified by tweaking `vsc-install` version on `regice` and (locally) rebuilding `vsc-jobs` RPM (without pushing it to `geodude` repo).