### PR TITLE
add "inconsistent-return-statements" to the whitelist

### DIFF
--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -116,7 +116,7 @@ PROSPECTOR_WHITELIST = [
     'redefined-builtin',
     'print-statement',  # use print() and from future import __print__ instead of print
     'metaclass-assignment',  # __metaclass__ doesn't exist anymore in python3
-    'inconsistent-return-statements', # Either all or none return statements in a function should return an expression.
+    'inconsistent-return-statements', # Either all or no return statements in a function should return an expression.
 ]
 
 # Prospector commandline options (positional path is added automatically)

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -116,6 +116,7 @@ PROSPECTOR_WHITELIST = [
     'redefined-builtin',
     'print-statement',  # use print() and from future import __print__ instead of print
     'metaclass-assignment',  # __metaclass__ doesn't exist anymore in python3
+    'inconsistent-return-statements', # Either all return statements in a function should return an expression, or none of them should.
 ]
 
 # Prospector commandline options (positional path is added automatically)

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -116,7 +116,7 @@ PROSPECTOR_WHITELIST = [
     'redefined-builtin',
     'print-statement',  # use print() and from future import __print__ instead of print
     'metaclass-assignment',  # __metaclass__ doesn't exist anymore in python3
-    'inconsistent-return-statements', # Either all return statements in a function should return an expression, or none of them should.
+    'inconsistent-return-statements', # Either all or none return statements in a function should return an expression.
 ]
 
 # Prospector commandline options (positional path is added automatically)

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -156,7 +156,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.12.4'
+VERSION = '0.12.5'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 


### PR DESCRIPTION
I was bitten by this in a script with nasty side effects. Can we enable this?
to prevent following example like functions returning None:

```
def test:
    if something:
        return integer
```
