### PR TITLE
Make sure that grep never uses colors

### DIFF
--- a/bin/python-stripped-env
+++ b/bin/python-stripped-env
@@ -33,6 +33,9 @@ set -e -u
 # actual python binary that we'll call
 PYTHON=/usr/bin/python
 
+# avoid weird issue with grep (for example, colored output)
+unset GREP_OPTIONS
+
 # only actually print debug info if $PYTHON_STRIPPED_ENV_DEBUG is defined
 function debug {
     if [ ! -z ${PYTHON_STRIPPED_ENV_DEBUG:-} ]; then
@@ -43,14 +46,14 @@ function debug {
 debug "which python: $(which python)"
 
 # unset all $LD_* environment variables
-for env_var in $(env | egrep --color=never '^LD_' | cut -f1 -d'='); do
+for env_var in $(env | egrep '^LD_' | cut -f1 -d'='); do
     debug "Unsetting \$$env_var (value was: ${!env_var})"
     unset $env_var
 done
 
 debug "All \$PYTHON* environment variables that matter are ignored by using 'python -E'"
 debug "Found defined \$PYTHON* environment variables:"
-for env_var in $(env | grep --color=never '^PYTHON' | cut -f1 -d'=' | grep --color=never -v PYTHON_STRIPPED_ENV_DEBUG); do
+for env_var in $(env | grep '^PYTHON' | cut -f1 -d'=' | grep -v PYTHON_STRIPPED_ENV_DEBUG); do
     debug "> \$$env_var was: ${!env_var}"
 done
 

--- a/bin/python-stripped-env
+++ b/bin/python-stripped-env
@@ -43,14 +43,14 @@ function debug {
 debug "which python: $(which python)"
 
 # unset all $LD_* environment variables
-for env_var in $(env | egrep '^LD_' | cut -f1 -d'='); do
+for env_var in $(env | egrep --color=never '^LD_' | cut -f1 -d'='); do
     debug "Unsetting \$$env_var (value was: ${!env_var})"
     unset $env_var
 done
 
 debug "All \$PYTHON* environment variables that matter are ignored by using 'python -E'"
 debug "Found defined \$PYTHON* environment variables:"
-for env_var in $(env | grep '^PYTHON' | cut -f1 -d'=' | grep -v PYTHON_STRIPPED_ENV_DEBUG); do
+for env_var in $(env | grep --color=never '^PYTHON' | cut -f1 -d'=' | grep --color=never -v PYTHON_STRIPPED_ENV_DEBUG); do
     debug "> \$$env_var was: ${!env_var}"
 done
 

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -157,7 +157,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.12.7'
+VERSION = '0.12.8'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 


### PR DESCRIPTION
We had a user that had:
```bash
export GREP_OPTIONS='--color=always'
```
in his `.bash_profile` and it breaks python-stripped-env.