### PR TITLE
Ignore user site directory in python-stripped-env

### DIFF
--- a/bin/python-noenv.sh
+++ b/bin/python-noenv.sh
@@ -25,5 +25,9 @@
 # along with vsc-install. If not, see <http://www.gnu.org/licenses/>.
 #
 ### END OF HEADER
-# the -s makes sure the user site package is also ignored
+#
+# env -i: start with an empty environment
+# -s: ignore $HOME/.local/python*/site-packages
+# see https://docs.python.org/2/using/cmdline.html#cmdoption-s
+# and https://docs.python.org/2/library/site.html#site.USER_SITE
 env -i /usr/bin/python -s "$@"

--- a/bin/python-noenv.sh
+++ b/bin/python-noenv.sh
@@ -25,4 +25,5 @@
 # along with vsc-install. If not, see <http://www.gnu.org/licenses/>.
 #
 ### END OF HEADER
-env -i /usr/bin/python "$@"
+# the -s makes sure the user site package is also ignored
+env -i /usr/bin/python -s "$@"

--- a/bin/python-stripped-env
+++ b/bin/python-stripped-env
@@ -57,5 +57,5 @@ for env_var in $(env | grep '^PYTHON' | cut -f1 -d'=' | grep -v PYTHON_STRIPPED_
     debug "> \$$env_var was: ${!env_var}"
 done
 
-debug "$PYTHON -E $(echo "$@")"
-$PYTHON -E "$@"
+debug "$PYTHON -s -E $(echo "$@")"
+$PYTHON -s -E "$@"

--- a/bin/python-stripped-env
+++ b/bin/python-stripped-env
@@ -38,15 +38,15 @@ unset GREP_OPTIONS
 
 # only actually print debug info if $PYTHON_STRIPPED_ENV_DEBUG is defined
 function debug {
-    if [ ! -z ${PYTHON_STRIPPED_ENV_DEBUG:-} ]; then
+    if [ -n "${PYTHON_STRIPPED_ENV_DEBUG:-}" ]; then
         echo "[python-stripped-env] $1"
     fi
 }
 
-debug "which python: $(which python)"
+debug "which python: $(command -v python)"
 
 # unset all $LD_* environment variables
-for env_var in $(env | egrep '^LD_' | cut -f1 -d'='); do
+for env_var in $(env | grep -E '^LD_' | cut -f1 -d'='); do
     debug "Unsetting \$$env_var (value was: ${!env_var})"
     unset $env_var
 done

--- a/bin/python-stripped-env
+++ b/bin/python-stripped-env
@@ -57,5 +57,10 @@ for env_var in $(env | grep '^PYTHON' | cut -f1 -d'=' | grep -v PYTHON_STRIPPED_
     debug "> \$$env_var was: ${!env_var}"
 done
 
+# -s: ignore $HOME/.local/python*/site-packages
+# see https://docs.python.org/2/using/cmdline.html#cmdoption-s
+# and https://docs.python.org/2/library/site.html#site.USER_SITE
+# -E: ignore $PYTHONPATH and $PYTHONHOME
+# see https://docs.python.org/2/using/cmdline.html#cmdoption-e
 debug "$PYTHON -s -E $(echo "$@")"
 $PYTHON -s -E "$@"

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -157,7 +157,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.12.9'
+VERSION = '0.12.10'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 


### PR DESCRIPTION
Things in `~/.local/lib/python2.7/` still get picked up by `python-stripped-env`

It seems like python 3 has something even better: `-I`.

