### PR TITLE
configure tox to pass down $USER into virtualenv used to run tests

### DIFF
--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -83,6 +83,9 @@ def gen_tox_ini():
         # (vsc-* packages may not work when installed with pip due to use of namespace package vsc.*)
         'commands_pre = python -m easy_install -U vsc-install',
         "commands = python setup.py test",
+        # $USER is not defined in tox environment, so pass it
+        # see https://tox.readthedocs.io/en/latest/example/basic.html#passing-down-environment-variables
+        'passenv = USER',
         '',
         # allow failing tests in Python 3, for now...
         '[testenv:%s]' % py3_env,

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -158,7 +158,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.13.1'
+VERSION = '0.13.2'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 

--- a/test/ci.py
+++ b/test/ci.py
@@ -78,6 +78,7 @@ class CITest(TestCase):
                 "[testenv]",
                 "commands_pre = python -m easy_install -U vsc-install",
                 "commands = python setup.py test",
+                "passenv = USER",
                 '',
                 "[testenv:py36]",
                 "ignore_outcome = true",

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ skip_missing_interpreters = true
 [testenv]
 commands_pre = python -m easy_install -U vsc-install
 commands = python setup.py test
+passenv = USER
 
 [testenv:py36]
 ignore_outcome = true


### PR DESCRIPTION
fix for:

```
Traceback (most recent call last):
  File "/var/lib/jenkins/jobs/hpc ugent github.com/jobs/vsc-config/branches/PR-98/workspace/test/env.py", line 170, in setUp
    self.orig_user = os.environ['USER']
  File "/var/lib/jenkins/jobs/hpc ugent github.com/jobs/vsc-config/branches/PR-98/workspace/.tox/py27/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'USER'
```