### PR TITLE
setuptools < 42.0 is required for now [HPC-7603]

### DIFF
--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -79,9 +79,10 @@ def gen_tox_ini():
         "skip_missing_interpreters = true",
         '',
         '[testenv]',
-        # use easy_install rather than pip to install vsc-install dependency
-        # (vsc-* packages may not work when installed with pip due to use of namespace package vsc.*)
-        'commands_pre = python -m easy_install -U vsc-install',
+        # install latest vsc-install release from PyPI;
+        # it's important to use pip (not easy_install) here, because vsc-install may require a specific
+        # version of setuptools for example (and only pip will actually remove an older already installed version)
+        "commands_pre = pip install -U vsc-install",
         "commands = python setup.py test",
         # $USER is not defined in tox environment, so pass it
         # see https://tox.readthedocs.io/en/latest/example/basic.html#passing-down-environment-variables

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -58,6 +58,7 @@ try:
     _old_basicconfig = logging.basicConfig
     from prospector.run import Prospector
     from prospector.config import ProspectorConfig
+    from prospector.__pkginfo__ import __version__ as prospector_version
     HAS_PROSPECTOR = True
     # restore in case pyroma is missing (see https://github.com/landscapeio/prospector/pull/156)
     logging.basicConfig = _old_basicconfig
@@ -140,6 +141,8 @@ PROSPECTOR_OPTIONS = [
 def run_prospector(base_dir, clear_ignore_patterns=False):
     """Run prospector and apply white/blacklists to the results"""
     orig_expand_default = optparse.HelpFormatter.expand_default
+
+    log.info("Using prosector version %s", prospector_version)
 
     sys.argv = ['fakename']
     sys.argv.extend(PROSPECTOR_OPTIONS)

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -47,6 +47,7 @@ import os
 import shutil
 import re
 
+import setuptools
 import setuptools.command.test
 
 from distutils import log  # also for setuptools
@@ -158,9 +159,10 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.13.3'
+VERSION = '0.13.4'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
+log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))
 
 # list of non-vsc packages that do not need python- prefix for correct rpm dependencies
 # vsc packages should be handled with clusterbuildrpm
@@ -1557,7 +1559,10 @@ if __name__ == '__main__':
     This main is the setup.py for vsc-install
     """
     install_requires = [
-        'setuptools',
+        # setuptools 42.0 changed easy_install to use pip if it's available,
+        # but vsc-install relies on the setuptools' behaviour of ignoring failing dependency installations and
+        # just continuing with the next entry in dependency_links
+        'setuptools<42.0',
         'mock',
     ]
 

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1416,7 +1416,8 @@ class vsc_setup(object):
             tests_requires = new_target.setdefault('tests_require', [])
             # Python 2.x support was removed in pydocstyle 4.0, so stick to latest release before 4.0
             tests_requires.append('pydocstyle < 4.0')
-            tests_requires.append('prospector >= 1.1.6.3b')
+            # fix from https://github.com/PyCQA/prospector/pull/323 required to avoid infinite recursion
+            tests_requires.append('prospector >= 1.1.6.4')
             deplinks = new_target.setdefault('dependency_links', [])
             deplinks.append("git+https://github.com/stdweird/prospector#egg=prospector-1.1.6.3b")
             new_target['tests_require'] = tests_requires
@@ -1575,9 +1576,6 @@ if __name__ == '__main__':
             'setuptools',
         ],
         'excluded_pkgs_rpm': [],  # vsc-install ships vsc package (the vsc package is removed by default)
-        'dependency_links': [
-            "git+https://github.com/stdweird/prospector#egg=prospector-1.1.6.2",
-        ],
     }
 
     action_target(PACKAGE)

--- a/test/ci.py
+++ b/test/ci.py
@@ -76,7 +76,7 @@ class CITest(TestCase):
                 "skip_missing_interpreters = true",
                 '',
                 "[testenv]",
-                "commands_pre = python -m easy_install -U vsc-install",
+                "commands_pre = pip install -U vsc-install",
                 "commands = python setup.py test",
                 "passenv = USER",
                 '',

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ skipsdist = true
 skip_missing_interpreters = true
 
 [testenv]
-commands_pre = python -m easy_install -U vsc-install
+commands_pre = pip install -U vsc-install
 commands = python setup.py test
 passenv = USER
 


### PR DESCRIPTION
`setuptools` 42.0 has changed the `easy_install` function to use `pip` if it's available, which breaks some assumptions currently made by `vsc-install`, primarily that failing installations using the URLs in `dependency_links` are safe to ignore