### PR TITLE
add support for specifying in vsc-ci.ini that tests must pass using Python 3 (and use it for vsc-install) (HPC-7603)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
     }
     stage('test') {
         sh 'python2.7 -V'
-        sh 'python -m easy_install -U --user tox'
+        sh 'pip3 install --user tox'
         sh 'export PATH=$HOME/.local/bin:$PATH && tox -v -c tox.ini'
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
     }
     stage('test') {
         sh 'python2.7 -V'
-        sh 'pip3 install --user tox'
+        sh 'pip3 install --ignore-installed --user tox'
         sh 'export PATH=$HOME/.local/bin:$PATH && tox -v -c tox.ini'
     }
 }

--- a/README.md
+++ b/README.md
@@ -460,3 +460,13 @@ To require that the test suite passes when run with Python 3, you must opt-in to
 [vsc-ci]
 py3_tests_must_pass=1
 ```
+
+Use 'pip3' to install tox
+-------------------------
+
+On systems that have Python 3 and `pip3` installed, it is recommended to opt-in to use `pip3 install` to install tox:
+
+```ini
+[vsc-ci]
+pip3_install_tox=1
+```

--- a/README.md
+++ b/README.md
@@ -424,3 +424,15 @@ add a configuration file for `python -m vsc.install.ci` named `vsc-ci.ini` like 
 [vsc-ci]
 jira_issue_id_in_pr_title=1
 ```
+
+
+Requiring that tests pass using Python 3
+----------------------------------------
+
+To require that the test suite passes when run with Python 3, you must opt-in to generating a tox configuration file
+(tox.ini) that does not ignore a missing interpreter or failing tests, using a `vsc-ci.ini` configuration file like:
+
+```ini
+[vsc-ci]
+py3_tests_must_pass=1
+```

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -52,6 +52,7 @@ VSC_CI_INI = VSC_CI + '.ini'
 
 INSTALL_SCRIPTS_PREFIX_OVERRIDE = 'install_scripts_prefix_override'
 JIRA_ISSUE_ID_IN_PR_TITLE = 'jira_issue_id_in_pr_title'
+PIP3_INSTALL_TOX = 'pip3_install_tox'
 PY3_TESTS_MUST_PASS = 'py3_tests_must_pass'
 RUN_SHELLCHECK = 'run_shellcheck'
 
@@ -148,6 +149,7 @@ def parse_vsc_ci_cfg():
     vsc_ci_cfg = {
         INSTALL_SCRIPTS_PREFIX_OVERRIDE: False,
         JIRA_ISSUE_ID_IN_PR_TITLE: False,
+        PIP3_INSTALL_TOX: False,
         PY3_TESTS_MUST_PASS: False,
         RUN_SHELLCHECK: False,
     }
@@ -189,10 +191,15 @@ def gen_jenkinsfile():
         # since we've configured tox to ignore failures due to missing Python interpreters
         # (see skip_missing_interpreters in gen_tox_ini)
         'python2.7 -V',
-        'python -m easy_install -U --user tox',
-        # make sure 'tox' command installed with --user is available via $PATH
-        'export PATH=$HOME/.local/bin:$PATH && tox -v -c %s' % TOX_INI,
     ]
+
+    if vsc_ci_cfg[PIP3_INSTALL_TOX]:
+        test_cmds.append('pip3 install --user tox')
+    else:
+        test_cmds.append('python -m easy_install -U --user tox')
+
+    # make sure 'tox' command installed with --user is available via $PATH
+    test_cmds.append('export PATH=$HOME/.local/bin:$PATH && tox -v -c %s' % TOX_INI)
 
     header = [
         "%s: scripted Jenkins pipefile" % JENKINSFILE,

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -194,11 +194,11 @@ def gen_jenkinsfile():
     ]
 
     if vsc_ci_cfg[PIP3_INSTALL_TOX]:
-        test_cmds.append('pip3 install --user tox')
+        test_cmds.append('pip3 install --ignore-installed --user tox')
     else:
         test_cmds.append('python -m easy_install -U --user tox')
 
-    # make sure 'tox' command installed with --user is available via $PATH
+    # make sure 'tox' command installed with --user is available via $PATH/$PYTHONPATH
     test_cmds.append('export PATH=$HOME/.local/bin:$PATH && tox -v -c %s' % TOX_INI)
 
     header = [

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -159,7 +159,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.14.3'
+VERSION = '0.14.4'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/test/ci.py
+++ b/test/ci.py
@@ -89,6 +89,12 @@ ignore_outcome = true
 class CITest(TestCase):
     """License related tests"""
 
+    def setUp(self):
+        """Test setup."""
+        super(CITest, self).setUp()
+
+        os.chdir(self.tmpdir)
+
     def write_vsc_ci_ini(self, txt):
         """Write vsc-ci.ini file in current directory with specified contents."""
         fh = open('vsc-ci.ini', 'w')
@@ -99,7 +105,6 @@ class CITest(TestCase):
 
     def test_parse_vsc_ci_cfg(self):
         """Test parse_vsc_ci_cfg function."""
-        os.chdir(self.tmpdir)
 
         # (basically) empty vsc-ci.ini
         self.write_vsc_ci_ini('')
@@ -128,7 +133,6 @@ class CITest(TestCase):
     def test_gen_jenkinsfile_jira_issue_id_in_pr_title(self):
         """Test generating of Jenkinsfile incl. check for JIRA issue in PR title."""
 
-        os.chdir(self.tmpdir)
         self.write_vsc_ci_ini('jira_issue_id_in_pr_title=1')
 
         jenkinsfile_txt = gen_jenkinsfile()
@@ -141,7 +145,6 @@ class CITest(TestCase):
     def test_tox_ini_py3_tests(self):
         """Test generation of tox.ini when Python 3 tests are expected to pass."""
 
-        os.chdir(self.tmpdir)
         self.write_vsc_ci_ini('py3_tests_must_pass=1')
 
         expected = EXPECTED_TOX_INI.replace('skip_missing_interpreters = true\n', '')

--- a/test/ci.py
+++ b/test/ci.py
@@ -124,14 +124,17 @@ class CITest(TestCase):
     def test_parse_vsc_ci_cfg(self):
         """Test parse_vsc_ci_cfg function."""
 
+        keys = [
+            'install_scripts_prefix_override',
+            'jira_issue_id_in_pr_title',
+            'pip3_install_tox',
+            'py3_tests_must_pass',
+            'run_shellcheck',
+        ]
+
         # (basically) empty vsc-ci.ini
         self.write_vsc_ci_ini('')
-        expected = {
-            'install_scripts_prefix_override': False,
-            'jira_issue_id_in_pr_title': False,
-            'py3_tests_must_pass': False,
-            'run_shellcheck': False,
-        }
+        expected = dict((key, False) for key in keys)
         self.assertEqual(parse_vsc_ci_cfg(), expected)
 
         # vsc-ci.ini with unknown keys is trouble
@@ -139,18 +142,8 @@ class CITest(TestCase):
         error_msg = "Unknown key in vsc-ci.ini: unknown_key"
         self.assertErrorRegex(ValueError, error_msg, parse_vsc_ci_cfg)
 
-        self.write_vsc_ci_ini('\n'.join([
-            'install_scripts_prefix_override=1',
-            'jira_issue_id_in_pr_title=1',
-            'py3_tests_must_pass=1',
-            'run_shellcheck=true',
-        ]))
-        expected = {
-            'install_scripts_prefix_override': True,
-            'jira_issue_id_in_pr_title': True,
-            'py3_tests_must_pass': True,
-            'run_shellcheck': True,
-        }
+        self.write_vsc_ci_ini('\n'.join('%s=1' % key for key in keys))
+        expected = dict((key, True) for key in keys)
         self.assertEqual(parse_vsc_ci_cfg(), expected)
 
     def test_gen_jenkinsfile(self):
@@ -182,7 +175,7 @@ class CITest(TestCase):
         self.write_vsc_ci_ini('py3_tests_must_pass=1')
 
         expected = EXPECTED_TOX_INI.replace('skip_missing_interpreters = true\n', '')
-        self.assertEqual(gen_tox_ini(), EXPECTED_TOX_INI)
+        self.assertEqual(gen_tox_ini(), expected)
 
     def test_tox_ini_install_script(self):
         """Test generating of tox.ini when install_scripts_prefix_override is set."""

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@
 [tox]
 envlist = py27,py36
 skipsdist = true
-skip_missing_interpreters = true
 
 [testenv]
 commands_pre =
@@ -13,6 +12,3 @@ commands_pre =
     python -m easy_install -U vsc-install
 commands = python setup.py test
 passenv = USER
-
-[testenv:py36]
-ignore_outcome = true

--- a/vsc-ci.ini
+++ b/vsc-ci.ini
@@ -1,2 +1,3 @@
 [vsc-ci]
+pip3_install_tox=1
 py3_tests_must_pass=1

--- a/vsc-ci.ini
+++ b/vsc-ci.ini
@@ -1,0 +1,2 @@
+[vsc-ci]
+py3_tests_must_pass=1


### PR DESCRIPTION
(marked WIP because tests will currently fail on Jenkins because there is no Python 3.6 available yet there, will be fixed in new Jenkins setup...)