### PR TITLE
allow redefining of 'reduce' builtin by blacklisting corresponding prospector message

### DIFF
--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -77,6 +77,7 @@ PROSPECTOR_BLACKLIST = [
     # 'wrong-import-position',  # not sure about this, these usually have a good reason
     'Locally disabling',  # shows up when you locally disable a warning, this is the point
     'Useless suppression',  # shows up when you locally disable/suppress a warning, this is the point
+    "Redefining built-in 'reduce'",  # allow importing reduce from functools, required for Python 3 compatibility
 ]
 # to dissable any of these warnings in a block, you can do things like add a comment # pylint: disable=C0321
 PROSPECTOR_WHITELIST = [

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -159,7 +159,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.14.2'
+VERSION = '0.14.3'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))


### PR DESCRIPTION
In places where we use `reduce` (built-in in Python 2, but not in Python 3), we need to use:

```
from functools import reduce
```

to make the code compatible with Python 3.

To avoid that `prospector` bitches about redefining the `reduce` builtin when the tests are run with Python 2, we need to blacklist the corresponding message...

The "redefinition" of `reduce` is a false positive in Python 2 btw:

```
>>> type(reduce)
<type 'builtin_function_or_method'>
>>> from functools import reduce
>>> type(reduce)
<type 'builtin_function_or_method'>
>>>
```