### PR TITLE
also run 'git clean -fxd' in Jenkinsfile to remove untracked files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,8 @@
 node {
     stage('checkout git') {
         checkout scm
+        // remove untracked files (*.pyc for example)
+        sh 'git clean -fxd'
     }
     stage('test') {
         sh 'python2.7 -V'

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -174,6 +174,8 @@ def gen_jenkinsfile():
         "node {",
         indent("stage('checkout git') {"),
         indent("checkout scm", level=2),
+        indent("// remove untracked files (*.pyc for example)", level=2),
+        indent("sh 'git clean -fxd'", level=2),
         indent('}'),
         indent("stage('test') {"),
     ]

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -159,7 +159,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.14.3'
+VERSION = '0.14.4'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/test/ci.py
+++ b/test/ci.py
@@ -41,6 +41,8 @@ EXPECTED_JENKINSFILE = """// Jenkinsfile: scripted Jenkins pipefile
 node {
     stage('checkout git') {
         checkout scm
+        // remove untracked files (*.pyc for example)
+        sh 'git clean -fxd'
     }
     stage('test') {
         sh 'python2.7 -V'


### PR DESCRIPTION
Jenkins doesn't re-create a clean checkout when it's re-running the tests for an existing PR (for example when a commit was added).

This can cause problems if `*.py` files were removed for some reason, since the corresponding `*.pyc` files will remain in place.

Fixed by running `git clean -fxd` after checkout, which was already present in some `Jenkinsfile`s (but it wasn't clear why, now it is).

Example of a failing test suite run without the `git clean`: https://github.com/hpcugent/jobcli/pull/76#issuecomment-571939211