### PR TITLE
add support for opting in to also running shellcheck in generated Jenkinsfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,3 +424,13 @@ add a configuration file for `python -m vsc.install.ci` named `vsc-ci.ini` like 
 [vsc-ci]
 jira_issue_id_in_pr_title=1
 ```
+
+Running shellcheck
+------------------
+
+To also run `shellcheck` in the generated `Jenkinsfile`, specify this via a `vsc-ci.ini` configuration file:
+
+```ini
+[vsc-ci]
+run_shellcheck=1
+```

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -159,7 +159,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.14.4'
+VERSION = '0.14.5'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))


### PR DESCRIPTION
fixes #131 (see also https://github.ugent.be/hpcugent/quattor-host-mngmt-tools/pull/11)