### PR TITLE
Only inject dependency version when a equal is allowed

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -162,7 +162,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.14.11'
+VERSION = '0.14.12'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))
@@ -1436,7 +1436,7 @@ class vsc_setup(object):
             if dependency.startswith('vsc'):
                 dep = dependency.split(' ')[0]
                 depversion = ''
-                for comp in ['==', '<', '<=']:
+                for comp in ['==', '<=', '>=']:
                     try:
                         depversion = "-" + dependency.split(comp)[1].strip()
                     except IndexError:

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1436,7 +1436,9 @@ class vsc_setup(object):
             if dependency.startswith('vsc'):
                 dep = dependency.split(' ')[0]
                 depversion = ''
-                for comp in ['==', '<=', '>=']:
+                # if you specify any kind of version on a dependency, the depedency_links also needs a version or
+                # else it's ignored.
+                for comp in COMPARISON_OPERATORS:
                     try:
                         depversion = "-" + dependency.split(comp)[1].strip()
                     except IndexError:

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1437,7 +1437,7 @@ class vsc_setup(object):
                 dep = dependency.split(' ')[0]
                 depversion = ''
                 # if you specify any kind of version on a dependency, the depedency_links also needs a version or
-                # else it's ignored.
+                # else it's ignored: https://setuptools.readthedocs.io/en/latest/setuptools.html#id14
                 for comp in COMPARISON_OPERATORS:
                     try:
                         depversion = "-" + dependency.split(comp)[1].strip()


### PR DESCRIPTION
Inject dependency links with expliciet version is only useful when `==`,
`>=` or `<=` is used. If there is not a `=`, the dependency links is
pointless.