### PR TITLE
consider git+https:// before git+ssh:// URLs for dependencies

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -159,7 +159,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.15.0'
+VERSION = '0.15.1'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))
@@ -1422,9 +1422,9 @@ class vsc_setup(object):
 
         if self.private_repo:
             urls = [
+                ('github.com', 'git+https://'),
                 ('github.ugent.be', 'git+ssh://git@'),
                 ('github.com', 'git+ssh://git@'),
-                ('github.com', 'git+https://'),
             ]
         else:
             urls = [('github.com', 'git+https://')]


### PR DESCRIPTION
When private repositories (like `vsc-config`) are being tested through `tox`, dependencies that are located in a public repo (for example `vsc-base` as a dep for `vsc-config`) should be cloned over `https` rather than `ssh` to avoid that the `git clone` command requires credentials (see #124).