### PR TITLE
stop using deprecated assertEquals, use assertEqual instead

### DIFF
--- a/test/shared_setup.py
+++ b/test/shared_setup.py
@@ -213,9 +213,9 @@ class TestSetup(TestCase):
         klass.SHARED_TARGET['cmdclass']['easy_install'] = object
         new_target = setup.parse_target(package)
 
-        self.assertEquals(new_target['name'], 'vsc-test')
-        self.assertEquals(new_target['version'], '1.0')
-        self.assertEquals(new_target['long_description_content_type'], 'text/markdown')
+        self.assertEqual(new_target['name'], 'vsc-test')
+        self.assertEqual(new_target['version'], '1.0')
+        self.assertEqual(new_target['long_description_content_type'], 'text/markdown')
         self.assertTrue(new_target['long_description'].startswith("Description\n==========="))
 
         klass.SHARED_TARGET = orig_target


### PR DESCRIPTION
Doesn't require a version bump, since it's only in the tests, and doesn't change anything functionally...