### PR TITLE
use correct URL for shellcheck

### DIFF
--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -236,9 +236,11 @@ def gen_jenkinsfile():
     ]
 
     if vsc_ci_cfg[RUN_SHELLCHECK]:
-        # see https://github.com/koalaman/shellcheck#installing
-        shellcheck_url = 'https://storage.googleapis.com/shellcheck/shellcheck-latest.linux.x86_64.tar.xz'
-        lines.extend([indent("stage ('shellcheck') {"),
+        # see https://github.com/koalaman/shellcheck#installing-a-pre-compiled-binary
+        shellcheck_url = 'https://github.com/koalaman/shellcheck/releases/download/latest/'
+        shellcheck_url += 'shellcheck-latest.linux.x86_64.tar.xz'
+        lines.extend([
+            indent("stage ('shellcheck') {"),
             indent("sh 'curl --silent %s --output - | tar -xJv'" % shellcheck_url, level=2),
             indent("sh 'cp shellcheck-latest/shellcheck .'", level=2),
             indent("sh 'rm -r shellcheck-latest'", level=2),
@@ -246,7 +248,6 @@ def gen_jenkinsfile():
             indent("sh './shellcheck bin/*.sh'", level=2),
             indent('}')
         ])
-
 
     lines.append(indent("stage('test') {"))
     lines.extend([indent("sh '%s'" % c, level=2) for c in test_cmds])

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -159,7 +159,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.15.3'
+VERSION = '0.15.4'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/test/ci.py
+++ b/test/ci.py
@@ -81,7 +81,7 @@ EXPECTED_JENKINSFILE_JIRA = JENKINSFILE_INIT + JENKINSFILE_TEST_STAGE + """    s
 """
 
 JENKINSFILE_SHELLCHECK_STAGE = """    stage ('shellcheck') {
-        sh 'curl --silent https://storage.googleapis.com/shellcheck/shellcheck-latest.linux.x86_64.tar.xz --output - | tar -xJv'
+        sh 'curl --silent https://github.com/koalaman/shellcheck/releases/download/latest/shellcheck-latest.linux.x86_64.tar.xz --output - | tar -xJv'
         sh 'cp shellcheck-latest/shellcheck .'
         sh 'rm -r shellcheck-latest'
         sh './shellcheck --version'


### PR DESCRIPTION
`shellcheck` downloaded from `storage.googleapis.com` URL fails with:

```
+ ./shellcheck --version
You are downloading ShellCheck from the wrong URL!
Please update to the latest one:
https://github.com/koalaman/shellcheck/releases/download/latest/shellcheck-latest.linux.x86_64.tar.xz

For more information, see:
https://github.com/koalaman/shellcheck/issues/1871
```

See also https://github.com/koalaman/shellcheck/issues/1871