### PR TITLE
clean up .eggs directory in tox.ini before running tests

### DIFF
--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -127,7 +127,10 @@ def gen_tox_ini():
         # vsc/__init__.py is not installed because we're using pkg_resources.declare_namespace
         # (see https://github.com/pypa/pip/issues/1924)
         "    python -m easy_install -U %svsc-install" % easy_install_args,
-        "commands = python setup.py test",
+        "commands =",
+        "    # clean up .eggs directory to avoid mixing Python packages installed with Python 2 & 3",
+        "    rm -rf .eggs",
+        "    python setup.py test",
         # $USER is not defined in tox environment, so pass it
         # see https://tox.readthedocs.io/en/latest/example/basic.html#passing-down-environment-variables
         'passenv = USER',

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -159,7 +159,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.15.6'
+VERSION = '0.15.7'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/test/ci.py
+++ b/test/ci.py
@@ -104,7 +104,10 @@ skip_missing_interpreters = true
 commands_pre =
     pip install 'setuptools<42.0'
     python -m easy_install -U vsc-install
-commands = python setup.py test
+commands =
+    # clean up .eggs directory to avoid mixing Python packages installed with Python 2 & 3
+    rm -rf .eggs
+    python setup.py test
 passenv = USER
 """
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,8 @@ skipsdist = true
 commands_pre =
     pip install 'setuptools<42.0'
     python -m easy_install -U vsc-install
-commands = python setup.py test
+commands =
+    # clean up .eggs directory to avoid mixing Python packages installed with Python 2 & 3
+    rm -rf .eggs
+    python setup.py test
 passenv = USER


### PR DESCRIPTION
This is required to avoid mixing Python packages installed with Python 2 & 3, which can lead to issues like:

```
(shellcmd ['/var/lib/jenkins/jobs/hpcugent_github.ugent/jobs/vsc-burstbuffer/branches/PR-17/workspace/.tox/py36/bin/python', '-c', 'import vsc.burstbuffer; print(vsc.burstbuffer.__file__)']) output Failed to import the site module
Error processing line 1 of /var/lib/jenkins/jobs/hpcugent_github.ugent/jobs/vsc-burstbuffer/branches/PR-17/workspace/.tox/py36/lib/python3.6/site-packages/_virtualenv.pth:

Traceback (most recent call last):
  File "/usr/lib64/python3.6/site.py", line 168, in addpackage
    exec(line)
  File "<string>", line 1, in <module>
  File "/var/lib/jenkins/jobs/hpcugent_github.ugent/jobs/vsc-burstbuffer/branches/PR-17/workspace/.tox/py36/lib/python3.6/site-packages/_virtualenv.py", line 40, in <module>
    from importlib.abc import MetaPathFinder
  File "/usr/lib64/python3.6/importlib/__init__.py", line 57, in <module>
    import types
  File "/usr/lib64/python3.6/types.py", line 171, in <module>
    import functools as _functools
  File "/usr/lib64/python3.6/functools.py", line 21, in <module>
    from collections import namedtuple
  File "/usr/lib64/python3.6/collections/__init__.py", line 32, in <module>
    from reprlib import recursive_repr as _recursive_repr
  File "/var/lib/jenkins/jobs/hpcugent_github.ugent/jobs/vsc-burstbuffer/branches/PR-17/workspace/.eggs/future-0.18.2-py2.7.egg/reprlib/__init__.py", line 7, in <module>
    raise ImportError('This package should not be accessible on Python 3. '
ImportError: This package should not be accessible on Python 3. Either you are trying to run from the python-future src folder or your installation of python-future is corrupted.
```