### PR TITLE
use .eggs.py2 or .eggs.py3, depending on Python version being used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ MANIFEST
 
 # Packages
 .eggs
+.eggs.py2
+.eggs.py3
 *.egg
 *.egg-info
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,7 @@ setup.cfg
 MANIFEST
 
 # Packages
-.eggs
-.eggs.py2
-.eggs.py3
+.eggs*
 *.egg
 *.egg-info
 dist

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -127,10 +127,7 @@ def gen_tox_ini():
         # vsc/__init__.py is not installed because we're using pkg_resources.declare_namespace
         # (see https://github.com/pypa/pip/issues/1924)
         "    python -m easy_install -U %svsc-install" % easy_install_args,
-        "commands =",
-        "    # clean up .eggs directory to avoid mixing Python packages installed with Python 2 & 3",
-        "    rm -rf .eggs",
-        "    python setup.py test",
+        "commands = python setup.py test",
         # $USER is not defined in tox environment, so pass it
         # see https://tox.readthedocs.io/en/latest/example/basic.html#passing-down-environment-variables
         'passenv = USER',

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -76,7 +76,7 @@ except ImportError:
 # Test that these are matched by a .gitignore pattern
 GITIGNORE_PATTERNS = ['.pyc', '.pyo', '~']
 # .gitnore needs to contain these exactly
-GITIGNORE_EXACT_PATTERNS = ['.eggs', '.eggs.py2', '.eggs.py3']
+GITIGNORE_EXACT_PATTERNS = ['.eggs*']
 
 # private class variables to communicate
 # between VscScanningLoader and VscTestCommand
@@ -280,7 +280,6 @@ def get_egg_cache_dir_pyver(self):
     return egg_cache_dir_pyver
 
 
-setuptools.dist.Distribution.get_egg_cache_dir = get_egg_cache_dir_pyver
 setuptools.dist.Distribution.get_egg_cache_dir = get_egg_cache_dir_pyver
 
 

--- a/test/ci.py
+++ b/test/ci.py
@@ -104,10 +104,7 @@ skip_missing_interpreters = true
 commands_pre =
     pip install 'setuptools<42.0'
     python -m easy_install -U vsc-install
-commands =
-    # clean up .eggs directory to avoid mixing Python packages installed with Python 2 & 3
-    rm -rf .eggs
-    python setup.py test
+commands = python setup.py test
 passenv = USER
 """
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,5 @@ skipsdist = true
 commands_pre =
     pip install 'setuptools<42.0'
     python -m easy_install -U vsc-install
-commands =
-    # clean up .eggs directory to avoid mixing Python packages installed with Python 2 & 3
-    rm -rf .eggs
-    python setup.py test
+commands = python setup.py test
 passenv = USER


### PR DESCRIPTION
If this approach is better, I can also roll back the changes done in #150 in this PR, since they're not needed anymore...

It will still require to update `.gitignore` everywhere though, to add `.eggs.py2` and `.eggs.py3`.