### PR TITLE
don't install tox with --user in Jenkinsfile, use --prefix instead

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,8 @@ node {
     }
     stage('test') {
         sh 'python2.7 -V'
-        sh 'pip3 install --ignore-installed --user tox'
-        sh 'export PATH=$HOME/.local/bin:$PATH && tox -v -c tox.ini'
+        sh 'pip3 install --ignore-installed --prefix $PWD/.vsc-tox tox'
+        sh 'export PATH=$PWD/.vsc-tox/bin:$PATH && tox -v -c tox.ini'
+        sh 'rm -r $PWD/.vsc-tox'
     }
 }

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -215,10 +215,13 @@ def gen_jenkinsfile():
     if vsc_ci_cfg[PIP_INSTALL_TOX]:
         pip_args += '--ignore-installed --user'
 
+        # tox requires zipp: require zipp < 3.0 since newer version are Python 3 only
+        tox = '"zipp<3.0" tox'
+
         test_cmds.extend([
             install_cmd + ' --user --upgrade pip',
             # make sure correct 'pip' installation is used
-            'export PATH=$HOME/.local/bin:$PATH && %s %s tox' % (install_cmd, pip_args),
+            'export PATH=$HOME/.local/bin:$PATH && %s %s %s' % (install_cmd, pip_args, tox),
         ])
 
     elif vsc_ci_cfg[PIP3_INSTALL_TOX]:

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -212,8 +212,10 @@ def gen_jenkinsfile():
     else:
         install_cmd = "pip install"
 
+    prefix = os.path.join('$PWD', '.vsc-tox')
+
     if vsc_ci_cfg[PIP_INSTALL_TOX]:
-        pip_args += '--ignore-installed --user'
+        pip_args += '--ignore-installed --prefix %s' % prefix
 
         # tox requires zipp: require zipp < 3.0 since newer version are Python 3 only
         tox = '"zipp<3.0" tox'
@@ -226,7 +228,7 @@ def gen_jenkinsfile():
 
     elif vsc_ci_cfg[PIP3_INSTALL_TOX]:
         install_cmd = install_cmd.replace('pip ', 'pip3 ')
-        pip_args += '--ignore-installed --user'
+        pip_args += '--ignore-installed --prefix %s' % prefix
         test_cmds.append('%s %s tox' % (install_cmd, pip_args))
 
     else:
@@ -234,8 +236,12 @@ def gen_jenkinsfile():
         easy_install_args += '-U --user'
         test_cmds.append('%s %s tox' % (install_cmd, easy_install_args))
 
-    # make sure 'tox' command installed with --user is available via $PATH/$PYTHONPATH
-    test_cmds.append('export PATH=$HOME/.local/bin:$PATH && tox -v -c %s' % TOX_INI)
+    test_cmds.extend([
+        # make sure 'tox' command installed is available by updating $PATH
+        'export PATH=%s:$PATH && tox -v -c %s' % (os.path.join(prefix, 'bin'), TOX_INI),
+        # clean up tox installation
+        'rm -r $PWD/.vsc-tox',
+    ])
 
     header = [
         "%s: scripted Jenkins pipefile" % JENKINSFILE,

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -160,7 +160,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.15.17'
+VERSION = '0.15.18'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/test/ci.py
+++ b/test/ci.py
@@ -31,7 +31,7 @@ Test CI functionality
 import os
 import re
 
-from vsc.install.ci import TOX_INI, gen_jenkinsfile, gen_tox_ini, parse_vsc_ci_cfg
+from vsc.install.ci import gen_jenkinsfile, gen_tox_ini, parse_vsc_ci_cfg
 from vsc.install.testing import TestCase
 
 
@@ -49,10 +49,11 @@ node {
 
 EASY_INSTALL_TOX = "        sh 'python -m easy_install -U --user tox'\n"
 PIP_INSTALL_TOX = """        sh 'pip install --user --upgrade pip'
-        sh 'export PATH=$HOME/.local/bin:$PATH && pip install --ignore-installed --user "zipp<3.0" tox'
+        sh 'export PATH=$HOME/.local/bin:$PATH && pip install --ignore-installed --prefix $PWD/.vsc-tox "zipp<3.0" tox'
 """
-PIP3_INSTALL_TOX = "        sh 'pip3 install --ignore-installed --user tox'\n"
-TOX_RUN = "        sh 'export PATH=$HOME/.local/bin:$PATH && tox -v -c %s'\n" % TOX_INI
+PIP3_INSTALL_TOX = "        sh 'pip3 install --ignore-installed --prefix $PWD/.vsc-tox tox'\n"
+TOX_RUN = """        sh 'export PATH=$PWD/.vsc-tox/bin:$PATH && tox -v -c tox.ini'
+        sh 'rm -r $PWD/.vsc-tox'\n"""
 
 JENKINSFILE_TEST_START = """    stage('test') {
         sh 'python2.7 -V'

--- a/test/ci.py
+++ b/test/ci.py
@@ -49,7 +49,7 @@ node {
 
 EASY_INSTALL_TOX = "        sh 'python -m easy_install -U --user tox'\n"
 PIP_INSTALL_TOX = """        sh 'pip install --user --upgrade pip'
-        sh 'export PATH=$HOME/.local/bin:$PATH && pip install --ignore-installed --user tox'
+        sh 'export PATH=$HOME/.local/bin:$PATH && pip install --ignore-installed --user "zipp<3.0" tox'
 """
 PIP3_INSTALL_TOX = "        sh 'pip3 install --ignore-installed --user tox'\n"
 TOX_RUN = "        sh 'export PATH=$HOME/.local/bin:$PATH && tox -v -c %s'\n" % TOX_INI


### PR DESCRIPTION
This is done to avoid that the tests run for different repositories step on each others toes on `jenkins10`, by not using a shared tox installation in `$HOME/.local`...