### PR TITLE
--install-scripts install option should only be used in tox.ini, not in Jenkinsfile

### DIFF
--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -218,9 +218,6 @@ def gen_jenkinsfile():
     ]
 
     pip_args, easy_install_args = '', ''
-    if vsc_ci_cfg[INSTALL_SCRIPTS_PREFIX_OVERRIDE]:
-        pip_args = '--install-option="--install-scripts={envdir}/bin" '
-        easy_install_args = '--script-dir={envdir}/bin '
 
     install_subdir = '.vsc-tox'
 

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -160,7 +160,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.16.2'
+VERSION = '0.16.3'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/test/ci.py
+++ b/test/ci.py
@@ -285,4 +285,4 @@ class CITest(TestCase):
         pip3_regex = re.compile('pip3 install')
         pip3_install_scripts = pip_install_scripts.replace('pip ', 'pip3 ')
         expected_jenkinsfile = pip3_regex.sub(pip3_install_scripts, EXPECTED_JENKINSFILE_PIP3_INSTALL_TOX)
-        self.assertEqual(gen_jenkinsfile(), expected_jenkinsfile)
+        self.assertEqual(gen_jenkinsfile(), EXPECTED_JENKINSFILE_PIP3_INSTALL_TOX)


### PR DESCRIPTION
The `--install-scripts` option is only needed to override the one specified in `setup.cfg`, but the `pip install` commands in `Jenkinsfile` in repos where this is an issue are run from `$HOME` to ignore the `setup.cfg`

Using `--install-option` when installing `tox` in `Jenkinsfile` causes problems, because it trigers `pip` to not download pre-built wheels from PyPI:
```
UserWarning: Disabling all use of wheels due to the use of --build-options / --global-options / --install-options
```

The side effect of this is that `tox` dependencies like `virtualenv` need to be installed from source, which results in problems like:
```
setuptools >= 41 required to build
```

This is basically a bug in `vsc-install`, there's no point in passing the `--install-scripts` option when installing `tox` in `Jenkinsfile`...