### PR TITLE
Improve friendliness with Python 3

### DIFF
--- a/bin/python-stripped-env
+++ b/bin/python-stripped-env
@@ -31,27 +31,19 @@
 set -e -u
 
 # default python interpreter
-DEFAULT_PYTHON=/usr/bin/python
+PYTHON=/usr/bin/python
 
-# check arguments for any known python interpreter
+# check first argument for any known python interpreter
 first_arg=${1:-false}
 case "$first_arg" in
     python*)
-        # use first argument if it is an available interpreter
+        # replace $PYTHON with first argument if it's an available interpreter
         if command -v $1 &> /dev/null; then
             PYTHON=$(which $1)
-        else
-            # fallback to default option
-            PYTHON=$DEFAULT_PYTHON
         fi
         shift
         ;;
-    *)
-        # default interpreter if nothing was specified
-        PYTHON=$DEFAULT_PYTHON
-        ;;
 esac
-echo $PYTHON
 
 # avoid weird issue with grep (for example, colored output)
 unset GREP_OPTIONS

--- a/bin/python-stripped-env
+++ b/bin/python-stripped-env
@@ -30,8 +30,28 @@
 # -u  Treat unset variables as an error when substituting.
 set -e -u
 
-# actual python binary that we'll call
-PYTHON=/usr/bin/python
+# default python interpreter
+DEFAULT_PYTHON=/usr/bin/python
+
+# check arguments for any known python interpreter
+first_arg=${1:-false}
+case "$first_arg" in
+    python*)
+        # use first argument if it is an available interpreter
+        if command -v $1 &> /dev/null; then
+            PYTHON=$(which $1)
+        else
+            # fallback to default option
+            PYTHON=$DEFAULT_PYTHON
+        fi
+        shift
+        ;;
+    *)
+        # default interpreter if nothing was specified
+        PYTHON=$DEFAULT_PYTHON
+        ;;
+esac
+echo $PYTHON
 
 # avoid weird issue with grep (for example, colored output)
 unset GREP_OPTIONS
@@ -43,7 +63,7 @@ function debug {
     fi
 }
 
-debug "which python: $(command -v python)"
+debug "Python interpreter: $(command -v $PYTHON)"
 
 # unset all $LD_* environment variables
 for env_var in $(env | grep -E '^LD_' | cut -f1 -d'='); do

--- a/bin/python-stripped-env
+++ b/bin/python-stripped-env
@@ -36,7 +36,7 @@ PYTHON=/usr/bin/python
 # check first argument for any known python interpreter
 first_arg=${1:-false}
 case "$first_arg" in
-    python*)
+    python|python[23]|python[23].[0-9]*)
         # replace $PYTHON with first argument if it's an available interpreter
         if command -v $1 &> /dev/null; then
             PYTHON=$(which $1)

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -263,12 +263,29 @@ def _fvs(msg=None):
 
 
 def _read(source, read_lines=False):
-    """read a file, either in full or as a list (read_lines=True)"""
-    with open(source) as file_handle:
+    """read a file, either in full or as a list (read_lines=True) and decode UTF-8 files into ASCII"""
+
+    def file_read(file_handle, read_lines):
+        """raw read action on file handle, either in full or as a list (read_lines=True)"""
         if read_lines:
             txt = file_handle.readlines()
         else:
             txt = file_handle.read()
+        return txt
+
+    try:
+        with open(source) as file_handle:
+            txt = file_read(file_handle, read_lines)
+    except UnicodeDecodeError:
+        # Python 3 fails to read file encoded in utf-8, try again setting the encoding
+        with open(source, encoding='utf-8') as file_handle:
+            txt = file_read(file_handle, read_lines)
+        # decode to ASCII removing non-conformant characters
+        if read_lines:
+            txt = [line.encode('utf-8').decode('ascii', 'ignore') for line in txt]
+        else:
+            txt = txt.encode('utf-8').decode('ascii', 'ignore')
+
     return txt
 
 

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -662,7 +662,10 @@ class vsc_setup(object):
                     if pyshebang_reg.search(first_line):
                         log.info("going to adapt shebang for script %s" % fn)
                         dest, code = self._recopy(base_dir, fn)
-                        code = pyshebang_reg.sub(SHEBANG_STRIPPED_ENV_PYTHON, code)
+                        pyshebang_line = first_line.split()
+                        pyshebang_line[0] = SHEBANG_STRIPPED_ENV_PYTHON
+                        pyshebang_line = ' '.join(pyshebang_line)
+                        code = pyshebang_reg.sub(pyshebang_line, code)
                         self._write(dest, code)
             else:
                 log.info("no scripts to check for shebang")

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -160,7 +160,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.1'
+VERSION = '0.17.2'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -277,14 +277,9 @@ def _read(source, read_lines=False):
         with open(source) as file_handle:
             txt = file_read(file_handle, read_lines)
     except UnicodeDecodeError:
-        # Python 3 fails to read file encoded in utf-8, try again setting the encoding
-        with open(source, encoding='utf-8') as file_handle:
+        # file contains unicode characters, try again backslashing them
+        with open(source, encoding='ascii', errors="backslashreplace") as file_handle:
             txt = file_read(file_handle, read_lines)
-        # decode to ASCII removing non-conformant characters
-        if read_lines:
-            txt = [line.encode('utf-8').decode('ascii', 'ignore') for line in txt]
-        else:
-            txt = txt.encode('utf-8').decode('ascii', 'ignore')
 
     return txt
 


### PR DESCRIPTION
`vsc-install` fails to install itself with Python 3 due to the unicode characters in [README.md](https://github.com/hpcugent/vsc-install#old-raise-syntax). Files parsed by `_read()` are decoded as ASCII with strict errors for non-ascii characters. A solution in Python 3 keeping the current general encoding is to explicitly open the file as UTF-8 and then decode to ASCII removing those characters. The fix in https://github.com/hpcugent/vsc-install/commit/30368849e381a0758a6fa46feeda7da4784ff985 ensures that everything will work as usual in Python 2.

On the other hand, `python-stripped-env` is hardcoded to `/usr/bin/python`, which breaks any script exclusively targeting Python 3 with `#!/usr/bin/env python3`. The changes in https://github.com/hpcugent/vsc-install/commit/c3d6639b996d2b87cd7aded7690ab9cc8a05afe4 make `python-stripped-env` work in similar way to `#!/usr/bin/env` by accepting an argument indicating the python interpreter.