### PR TITLE
manipulate dependencies for rpm building

### DIFF
--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Ghent University
+# Copyright 2015-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/__init__.py
+++ b/lib/vsc/install/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Ghent University
+# Copyright 2015-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Ghent University
+# Copyright 2014-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/headers.py
+++ b/lib/vsc/install/headers.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Ghent University
+# Copyright 2015-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -166,7 +166,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.2'
+VERSION = '0.17.3'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2011-2020 Ghent University
+# Copyright 2011-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/testing.py
+++ b/lib/vsc/install/testing.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Ghent University
+# Copyright 2014-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 Ghent University
+# Copyright 2016-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 Ghent University
+# Copyright 2016-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/ci.py
+++ b/test/ci.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/commontest.py
+++ b/test/commontest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/headers.py
+++ b/test/headers.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 Ghent University
+# Copyright 2016-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/licenses.py
+++ b/test/licenses.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 Ghent University
+# Copyright 2016-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest.py
+++ b/test/prospectortest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 Ghent University
+# Copyright 2016-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/shared_setup.py
+++ b/test/shared_setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 Ghent University
+# Copyright 2016-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/shared_setup.py
+++ b/test/shared_setup.py
@@ -256,3 +256,49 @@ class TestSetup(TestCase):
 
         package['install_requires'].append('vsc-utils<=1.0.0')
         self.assertRaises(ValueError, setup.parse_target, package)
+
+    def test_parse_vsc_filter(self):
+        """Test injecting dependency_links in parse_target"""
+        inst_req = [
+            'vsc-config >= 2.0.0',
+            'vsc-accountpage-clients',
+            'vsc-base > 1.0.0',
+        ]
+
+        def pkg(vfr):
+            pkg = {
+                'name': 'vsc-test',
+                'excluded_pkgs_rpm': [],
+                'version': '1.0',
+                'install_requires': inst_req[:],
+            }
+            if vfr:
+                pkg.update(vfr)
+            return pkg
+
+        def test_target(vfr, expected):
+            setup = vsc_setup()
+            new_target = setup.parse_target(pkg(vfr))
+            self.assertEqual(new_target['install_requires'], expected)
+
+        vfr = {
+            'vsc_filter_rpm': {
+                'install_requires': [
+                    ['vsc-base.*', ''],
+                    ['^(vsc-config).*', '\g<1>'], # strip version info for vsc-config
+                ],
+            },
+        }
+
+        os.environ.pop('VSC_RPM_PYTHON', None)
+
+        # nothing in env, nothing passed as vfr
+        test_target({}, inst_req)
+        # nothing set in env
+        test_target(vfr, inst_req)
+
+        os.environ['VSC_RPM_PYTHON'] = '3'
+        # something in env, nothing passed as vfr
+        test_target({}, inst_req)
+        # something in env
+        test_target(vfr, ['vsc-config', 'vsc-accountpage-clients'])

--- a/test/testdata/vsc/__init__.py
+++ b/test/testdata/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Ghent University
+# Copyright 2015-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/testdata/vsc/test/__init__.py
+++ b/test/testdata/vsc/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Ghent University
+# Copyright 2015-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/testing.py
+++ b/test/testing.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2020 Ghent University
+# Copyright 2012-2021 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),


### PR DESCRIPTION
we have started adding restrictions to the requirements to work around limitations of pypi (specifically when certain dependencies are only supported for more recent python versions). however, we now have run into issues where these restrictions cause probems when making rpms while the too recent version issue does not exist in such an environment