### PR TITLE
give errors about logging-not-lazy

### DIFF
--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -195,7 +195,7 @@ def parse_vsc_ci_cfg():
             cfgparser.read(VSC_CI_INI)
             cfgparser.items(VSC_CI)  # just to make sure vsc-ci section is there
         except (configparser.NoSectionError, configparser.ParsingError) as err:
-            logging.error("ERROR: Failed to parse %s: %s" % (VSC_CI_INI, err))
+            logging.error("ERROR: Failed to parse %s: %s", VSC_CI_INI, err))
             sys.exit(1)
 
         # every entry in the vsc-ci section is expected to be a known setting

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -195,7 +195,7 @@ def parse_vsc_ci_cfg():
             cfgparser.read(VSC_CI_INI)
             cfgparser.items(VSC_CI)  # just to make sure vsc-ci section is there
         except (configparser.NoSectionError, configparser.ParsingError) as err:
-            logging.error("ERROR: Failed to parse %s: %s", VSC_CI_INI, err))
+            logging.error("ERROR: Failed to parse %s: %s", VSC_CI_INI, err)
             sys.exit(1)
 
         # every entry in the vsc-ci section is expected to be a known setting

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -105,7 +105,7 @@ PROSPECTOR_WHITELIST = [
     'E501',  # 'line too long'when a line is longer then 120 chars
     'line-too-long', # use fail using pylint as well (not only pep8 above)
     # 'protected-access',
-    # 'logging-not-lazy',
+    'logging-not-lazy',
     # will stop working in python3
     'unpacking-in-except',
     'redefine-in-handler',  # except A, B -> except (A, B)

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -120,6 +120,8 @@ PROSPECTOR_WHITELIST = [
     'print-statement',  # use print() and from future import __print__ instead of print
     'metaclass-assignment',  # __metaclass__ doesn't exist anymore in python3
     'inconsistent-return-statements', # Either all or no return statements in a function should return an expression.
+    'no-member',
+    'logging-too-few-args',
 ]
 
 # Prospector commandline options (positional path is added automatically)

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -166,7 +166,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.5'
+VERSION = '0.17.6'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))


### PR DESCRIPTION
I was cleaning up some code and I think its time to enable `logging-not-lazy`, the other 2 `no-member` and `logging-too-few-args` are needed to show bugs I encountered when cleaning up things.