### PR TITLE
enable pylint unnecessary-semicolon

### DIFF
--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -117,6 +117,7 @@ PROSPECTOR_WHITELIST = [
     'syntax-error',
     'trailing-whitespace',
     'undefined',
+    'unnecessary-semicolon',
     'unpacking-in-except', # will stop working in python3
     'unused-argument',
     'unused-import',

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -166,7 +166,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.8'
+VERSION = '0.17.9'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))


### PR DESCRIPTION
fail on code like:
```
self.output_clients(total_clients, total_sources);
```
