### PR TITLE
exclude bin/__pycache__ when doing local install

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -166,7 +166,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.7'
+VERSION = '0.17.8'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))
@@ -1432,7 +1432,7 @@ class vsc_setup(object):
 
         vsc_scripts = target.pop('vsc_scripts', True)
         if vsc_scripts:
-            candidates = self.generate_scripts()
+            candidates = self.generate_scripts(exclude=['__pycache__'])
             if candidates:
                 if 'scripts' in target:
                     old_scripts = target.pop('scripts', [])


### PR DESCRIPTION
when you run tox  it creates a `bin/__pycache__` directory. If you run `python setupy.py install --user` afterwards vsc-install refuses to install because the directory is there.

```
INFO: installing scripts to build/bdist.linux-x86_64/egg/EGG-INFO/scripts
INFO: running install_scripts
INFO: running build_scripts
INFO: creating build/scripts-3.9
error: [Errno 21] Is a directory: 'bin/__pycache__'
```

So I believe it should be ignored on install.
