### PR TITLE
enable pylint assignment-from-no-return

### DIFF
--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -90,6 +90,7 @@ PROSPECTOR_WHITELIST = [
     'F811',  # redefinition of unused name
     'W291',  # pep8: W291 / trailing whitespace
     'arguments-differ',
+    'assignment-from-no-return', # Assigning result of a function call, where the function has no return
     'backtick',  # don't use `variable` to turn a variable in a string, use the str() function
     'bad-indentation',
     'bad-whitespace',

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -697,13 +697,11 @@ class vsc_setup(object):
                 os.mkdir(setupper.REPO_LIB_DIR)
                 cleanup.append(setupper.REPO_LIB_DIR)
 
-            res = egg_info.finalize_options(self, *args, **kwargs)
+            egg_info.finalize_options(self, *args, **kwargs)
 
             # cleanup any diretcories created
             for directory in cleanup:
                 shutil.rmtree(directory)
-
-            return res
 
         def find_sources(self):
             """Default lookup."""
@@ -1032,12 +1030,11 @@ class vsc_setup(object):
                 __import__(DEFAULT_TEST_SUITE)
             self.reload_modules(DEFAULT_TEST_SUITE)
 
-            res = TestCommand.run_tests(self)
+            TestCommand.run_tests(self)
 
             # cleanup any diretcories created
             for directory in cleanup:
                 shutil.rmtree(directory)
-            return res
 
     @staticmethod
     def add_and_remove(alist, extra=None, exclude=None):

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -166,7 +166,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.9'
+VERSION = '0.17.10'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))


### PR DESCRIPTION
this warns on possible logical issues like:

```
def function_without_return():                                                                                                                               
    x = 1 + 1                                                                                                                                                
    print(x)                                                                                                                                                 
                                                                                                                                                             
y = function_without_return()  
```
```
E1111: Assigning result of a function call, where the function has no return (assignment-from-no-return)
```

this is correct syntax, but is probably never what you want.