### PR TITLE
New name for VUB gh organization: vub-hpc

### DIFF
--- a/lib/vsc/install/headers.py
+++ b/lib/vsc/install/headers.py
@@ -292,7 +292,7 @@ institute_details = {
         'university_url': 'http://ugent.be/hpc',
         'university_team_url': 'http://ugent.be/hpc/en',
     },
-    'sisc-hpc': {
+    'vub-hpc': {
         'university_name': 'Vrije Universiteit Brussel',
         'university_url': 'https://www.vub.be',
         'university_team_url': 'https://hpc.vub.be',

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -147,7 +147,7 @@ ad = ('Alex Domingo', 'alex.domingo.toro@vub.be')
 # available remotes
 GIT_REMOTES = [
     'hpcugent',
-    'sisc-hpc',
+    'vub-hpc',
 ]
 
 # Regexp used to remove suffixes from scripts when installing(/packaging)
@@ -166,7 +166,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.10'
+VERSION = '0.17.11'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/test/headers.py
+++ b/test/headers.py
@@ -113,7 +113,7 @@ class TestHeaders(TestCase):
             'name': 'projectname',
             'beginyear': 1234,
             'endyear': 5678,
-            'url': 'https://github.com/sisc-hpc/projectname',
+            'url': 'https://github.com/vub-hpc/projectname',
         }
         for license in KNOWN_LICENSES.keys():
             res_fn = os.path.join(self.setup.REPO_TEST_DIR, 'headers', license)

--- a/test/setup/git_config_6
+++ b/test/setup/git_config_6
@@ -4,5 +4,5 @@
 	bare = false
 	logallrefupdates = true
 [remote "origin"]
-	url = git@github.com:sisc-hpc/vsc-jobs-brussel.git
+	url = git@github.com:vub-hpc/vsc-jobs-brussel.git
 	fetch = +refs/heads/*:refs/remotes/origin/*

--- a/test/shared_setup.py
+++ b/test/shared_setup.py
@@ -66,8 +66,8 @@ class TestSetup(TestCase):
         fn = 'git_config_6'
         res_brussel = {
             'name': 'vsc-jobs-brussel',
-            'url': 'https://github.com/sisc-hpc/vsc-jobs-brussel',
-            'download_url': 'https://github.com/sisc-hpc/vsc-jobs-brussel/archive/0.1.0.tar.gz',
+            'url': 'https://github.com/vub-hpc/vsc-jobs-brussel',
+            'download_url': 'https://github.com/vub-hpc/vsc-jobs-brussel/archive/0.1.0.tar.gz',
         }
         self.assertEqual(self.setup.get_name_url(os.path.join(self.setup.REPO_TEST_DIR, 'setup', fn), version='0.1.0'),
                          res_brussel,


### PR DESCRIPTION
The old name 'sisc-hpc' is no longer relevant.