### PR TITLE
fix tests for non-github repos

### DIFF
--- a/lib/vsc/install/headers.py
+++ b/lib/vsc/install/headers.py
@@ -135,7 +135,7 @@ def gen_license_header(license_name, **kwargs):
 
     found = False
     for github_organ in institute_details.keys():
-        if github_organ in kwargs.get('url', ''):
+        if github_organ in kwargs.get('url', '').lower():
             kwargs.update(institute_details[github_organ])
             found = True
             break
@@ -292,7 +292,7 @@ institute_details = {
         'university_url': 'http://ugent.be/hpc',
         'university_team_url': 'http://ugent.be/hpc/en',
     },
-    'vub-hpc': {
+    'vub': {
         'university_name': 'Vrije Universiteit Brussel',
         'university_url': 'https://www.vub.be',
         'university_team_url': 'https://hpc.vub.be',

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -167,7 +167,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.13'
+VERSION = '0.17.14'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -168,7 +168,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.14'
+VERSION = '0.17.15'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -425,6 +425,9 @@ class vsc_setup(object):
                 res['download_url'] = None
             elif 'github' in res.get('url', '') and version is not None:
                 res['download_url'] = "%s/archive/%s.tar.gz" % (res['url'], version)
+            else:
+                # other remotes have no external download url
+                res['download_url'] = None
 
         if len(res) != 3:
             raise Exception("Cannot determine name, url and download url from filename %s: got %s" % (filename, res))


### PR DESCRIPTION
Now that we can work with our non-github repos, we had a few test failures. 
* I'm changing our `institute_details` to just be VUB so it work for both our github and azure repos
* also setting a `download_url` to None for any non-github repo