### PR TITLE
remove restriction on flake8, both flake8 and prospector now require pyflakes < 2.4.0

### DIFF
--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -37,6 +37,7 @@ Running python setup.py test will pick this up and do its magic
 import logging
 import optparse
 import os
+import pkg_resources
 import pprint
 import re
 import sys
@@ -58,7 +59,7 @@ try:
     _old_basicconfig = logging.basicConfig
     from prospector.run import Prospector
     from prospector.config import ProspectorConfig
-    from prospector.__pkginfo__ import __version__ as prospector_version
+    prospector_version = pkg_resources.get_distribution("prospector").version
     HAS_PROSPECTOR = True
     # restore in case pyroma is missing (see https://github.com/landscapeio/prospector/pull/156)
     logging.basicConfig = _old_basicconfig

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -34,7 +34,6 @@ Running python setup.py test will pick this up and do its magic
 @author: Stijn De Weirdt (Ghent University)
 """
 
-import logging
 import optparse
 import os
 import pkg_resources
@@ -49,10 +48,6 @@ from vsc.install.ci import JENKINSFILE, TOX_INI, gen_jenkinsfile, gen_tox_ini
 from vsc.install.headers import check_header
 from vsc.install.shared_setup import vsc_setup
 from vsc.install.testing import TestCase
-
-_old_basicconfig = logging.basicConfig
-# restore in case pyroma is missing (see https://github.com/landscapeio/prospector/pull/156)
-logging.basicConfig = _old_basicconfig
 
 prospector_version = pkg_resources.get_distribution("prospector").version
 

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -41,7 +41,8 @@ import pkg_resources
 import pprint
 import re
 import sys
-import unittest
+from prospector.run import Prospector
+from prospector.config import ProspectorConfig
 
 from distutils import log
 from vsc.install.ci import JENKINSFILE, TOX_INI, gen_jenkinsfile, gen_tox_ini
@@ -49,23 +50,11 @@ from vsc.install.headers import check_header
 from vsc.install.shared_setup import vsc_setup
 from vsc.install.testing import TestCase
 
-# No prospector in py26 or earlier
-# Also not enforced on installation
-HAS_PROSPECTOR = False
-Prospector = None
-ProspectorConfig = None
+_old_basicconfig = logging.basicConfig
+# restore in case pyroma is missing (see https://github.com/landscapeio/prospector/pull/156)
+logging.basicConfig = _old_basicconfig
 
-try:
-    _old_basicconfig = logging.basicConfig
-    from prospector.run import Prospector
-    from prospector.config import ProspectorConfig
-    prospector_version = pkg_resources.get_distribution("prospector").version
-    HAS_PROSPECTOR = True
-    # restore in case pyroma is missing (see https://github.com/landscapeio/prospector/pull/156)
-    logging.basicConfig = _old_basicconfig
-except ImportError:
-    pass
-
+prospector_version = pkg_resources.get_distribution("prospector").version
 
 # this sets the --uses commandline
 PROSPECTOR_USE_LIBS = []
@@ -322,7 +311,6 @@ class CommonTest(TestCase):
                 self.assertFalse(check_header(os.path.join(self.setup.REPO_BASE_DIR, scr), script=True, write=False),
                                  msg='check_header of %s' % scr)
 
-    @unittest.skipUnless(HAS_PROSPECTOR, "Prospector is not available, so prosprector tests were skipped")
     def test_prospector(self):
         """Test prospector failures"""
 

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -168,7 +168,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.16'
+VERSION = '0.17.17'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))
@@ -1490,10 +1490,7 @@ class vsc_setup(object):
             tests_requires.append('isort < 5.0')
         else:
             tests_requires.extend([
-                # stick to older flake8, to avoid version conflict on pyflakes dependency
-                # flake8 3.9.0 requires pyflakes<2.4.0,>=2.3.0
-                # prospector 1.3.1 requires pyflakes<2.3.0,>=2.2.0
-                'flake8 < 3.9.0',
+                'flake8',
                 'prospector',
                 'mock',
             ])

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -119,6 +119,7 @@ if log.Log.__name__ != 'NewLog':
                 return self._orig_log(self, level, newmsg, args)
             except Exception:
                 print(newmsg % args)
+                return None
 
     log.Log = NewLog
     log._global_log = NewLog()

--- a/test/prospectortest/lib/vsc/mockinstall/bad_whitespace.py
+++ b/test/prospectortest/lib/vsc/mockinstall/bad_whitespace.py
@@ -1,6 +1,0 @@
-"""Test bad_whitespace"""
-
-
-def a_a(b_b,  c_c):
-    """function a_a"""
-    return b_b + c_c


### PR DESCRIPTION
required to fix problem when running tests (for example for `vsc-config` in #155

```
pkg_resources.ContextualVersionConflict: (pyflakes 2.3.1 (/var/lib/jenkins/jobs/hpcugent_github.com/jobs/vsc-config/branches/PR-155/workspace/.eggs.py3/pyflakes-2.3.1-py3.6.egg), Requirement.parse('pyflakes<2.3.0,>=2.2.0'), {'flake8'})
```