### PR TITLE
fix dep hell for astroid/pylint/flake8/prospector by fixing major/minor versions

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1501,6 +1501,8 @@ class vsc_setup(object):
                 'astroid~=2.7.3',
                 # stick to pyflakes < 2.3.0, as required by prospector 1.5.0.x and flake8 3.8.x
                 'pyflakes~=2.2.0',
+                # stick to pycodestyle < 2.7.0, as required by flake8 3.8.x
+                'pycodestyle~=2.6.0',
                 'pylint~=2.10.2',
                 'flake8~=3.8.4',
                 'prospector~=1.5.0.1',

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1490,11 +1490,19 @@ class vsc_setup(object):
             # isort 5.0 is no longer compatible with Python 2
             tests_requires.append('isort < 5.0')
         else:
+            # soft pinning of (transitive) dependencies of prospector
+            # ('~=' means stick to compatible release, https://www.python.org/dev/peps/pep-0440/#compatible-release);
+            # updating these must be done in lockstep, see setup.cfg or pyproject.toml or whatever at:
+            # - https://github.com/PyCQA/pylint/blob/v2.10.2/setup.cfg
+            # - https://github.com/PyCQA/flake8/blob/3.8.4/setup.cfg
+            # - https://github.com/PyCQA/prospector/blob/1.5.0.1/pyproject.toml
             tests_requires.extend([
                 # stick to astroid < 2.8, as required by pylint 2.10.x
                 'astroid~=2.7.3',
+                # stick to pyflakes < 2.3.0, as required by prospector 1.5.0.x and flake8 3.8.x
+                'pyflakes~=2.2.0',
                 'pylint~=2.10.2',
-                'flake8~=3.9.2',
+                'flake8~=3.8.4',
                 'prospector~=1.5.0.1',
                 'mock',
             ])

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -169,7 +169,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.17'
+VERSION = '0.17.18'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))
@@ -1491,8 +1491,11 @@ class vsc_setup(object):
             tests_requires.append('isort < 5.0')
         else:
             tests_requires.extend([
-                'flake8',
-                'prospector',
+                # stick to astroid < 2.8, as required by pylint 2.10.x
+                'astroid~=2.7.3',
+                'pylint~=2.10.2',
+                'flake8~=3.9.2',
+                'prospector~=1.5.0.1',
                 'mock',
             ])
 


### PR DESCRIPTION
The `~=` means "compatible release", see https://www.python.org/dev/peps/pep-0440/#compatible-release

This will hopefully save us for a while for the version conflicts that keep popping up for *every* Python package we have due to new releases for (transitive) dependencies of `prospector` & co...