### PR TITLE
don't test for python2 on py3 only projects

### DIFF
--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -231,12 +231,12 @@ def gen_jenkinsfile():
 
     vsc_ci_cfg = parse_vsc_ci_cfg()
 
-    test_cmds = [
+    test_cmds = []
+    if not vsc_ci_cfg[PY3_ONLY]:
         # make very sure Python 2.7 is available,
         # since we've configured tox to ignore failures due to missing Python interpreters
         # (see skip_missing_interpreters in gen_tox_ini)
-        'python2.7 -V',
-    ]
+        test_cmds.append('python2.7 -V')
 
     pip_args, easy_install_args = '', ''
 

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -169,7 +169,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.23'
+VERSION = '0.17.24'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))


### PR DESCRIPTION
as I'm preparing new test hosts that don't have python2.7 available anymore, I don't think this test should still be there on python3 only projects.

e.g. remove the following line from stage 'test':
```
    stage('test') {
        sh 'python2.7 -V'
    }
```