### PR TITLE
update gh action versions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -9,9 +9,9 @@ jobs:
           python: [2.7, 3.6, 3.9, 3.11]
       steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: install tox


### PR DESCRIPTION
avoid the deprecation warnings on nodejs 12.