### PR TITLE
start removing python 2 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ node {
         sh 'git clean -fxd'
     }
     stage('test') {
-        sh 'python2.7 -V'
         sh 'pip3 install --ignore-installed --prefix $PWD/.vsc-tox tox'
         sh 'export PATH=$PWD/.vsc-tox/bin:$PATH && export PYTHONPATH=$PWD/.vsc-tox/lib/python$(python3 -c "import sys; print(\\"%s.%s\\" % sys.version_info[:2])")/site-packages:$PYTHONPATH && tox -v -c tox.ini'
         sh 'rm -r $PWD/.vsc-tox'

--- a/README.md
+++ b/README.md
@@ -265,30 +265,6 @@ except (ExceptionOne, ExceptionTwo) ...
 
 (espcially when used like `except A, B:` which should be `except (A, B):`.
 
-Fixing print statement
-----------------------
-
-Use the oneliner:
-```bash
-find lib bin -name '*.py' | xargs futurize -w -f libfuturize.fixes.fix_print_with_import -n
-```
-Note: You need to install `python(2)-future` if you want to use `futurize` (or you have to have the `future` Python package).
-
-Metaclass assignment
---------------------
-
-```python
-class Foo(Bar):
-
-    __metaclass__ = Baz
-```
-=>
-```python
-from future.utils import with_metaclass
-
-class Foo(with_metaclass(Baz,Bar):
-```
-
 Old raise syntax
 ----------------
 Python 2’s **raise** statement was designed at a time when exceptions weren’t classes, and an exception’s _type_, _value_, and _traceback_ components were three separate objects. In Python 3, one single object includes all information about an exception.

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -31,13 +31,9 @@ Shared module for vsc software setup
 @author: Andy Georges (Ghent University)
 """
 
-from __future__ import print_function
 import sys
 
-if sys.version_info < (3, 0):
-    import __builtin__
-else:
-    import builtins as __builtin__  # make builtins accessible via same way as in Python 3
+import builtins as __builtin__  # make builtins accessible via same way as in Python 3
 
 import glob
 import hashlib
@@ -169,7 +165,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.17.32'
+VERSION = '0.18.0'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/test/ci.py
+++ b/test/ci.py
@@ -49,7 +49,7 @@ node {
 
 EASY_INSTALL_TOX = "        sh 'python -m easy_install -U --user tox'\n"
 PIP_INSTALL_TOX = """        sh 'pip install --user --upgrade pip'
-        sh 'export PATH=$HOME/.local/bin:$PATH && pip install --ignore-installed --prefix $PWD/.vsc-tox "zipp<3.0" tox'
+        sh 'export PATH=$HOME/.local/bin:$PATH && pip install --ignore-installed --prefix $PWD/.vsc-tox "zipp<3.7" tox'
 """
 PIP3_INSTALL_TOX = "        sh 'pip3 install --ignore-installed --prefix $PWD/.vsc-tox tox'\n"
 
@@ -58,7 +58,6 @@ TOX_RUN_PY3 = """        sh 'export PATH=$PWD/.vsc-tox/bin:$PATH && export PYTHO
 TOX_RUN_PY2 = TOX_RUN_PY3.replace('python3', 'python')
 
 JENKINSFILE_TEST_START = """    stage('test') {
-        sh 'python2.7 -V'
 """
 JENKINSFILE_END_STAGE = "    }\n"
 
@@ -99,7 +98,7 @@ EXPECTED_TOX_INI = """# tox.ini: configuration file for tox
 # DO NOT EDIT MANUALLY
 
 [tox]
-envlist = py27,py36
+envlist = py36
 skipsdist = true
 
 [testenv]
@@ -177,7 +176,7 @@ class CITest(TestCase):
             'pip_install_test_deps': None,
             'pip_install_tox': False,
             'pip3_install_tox': False,
-            'py3_only': False,
+            'py3_only': True,
             'py3_tests_must_pass': True,
             'run_shellcheck': False,
         }
@@ -298,15 +297,6 @@ class CITest(TestCase):
         self.write_vsc_ci_ini('inherit_site_packages=1')
 
         expected = EXPECTED_TOX_INI + 'sitepackages = true\n'
-        self.assertEqual(gen_tox_ini(), expected)
-
-    def test_tox_ini_py3_tests(self):
-        """Test generation of tox.ini when Python 3 tests are ignored."""
-
-        self.write_vsc_ci_ini('py3_tests_must_pass=0')
-
-        expected = EXPECTED_TOX_INI.replace('skipsdist = true', 'skipsdist = true\nskip_missing_interpreters = true')
-        expected += EXPECTED_TOX_INI_PY36_IGNORE
         self.assertEqual(gen_tox_ini(), expected)
 
     def test_tox_ini_py3_only(self):

--- a/test/shared_setup.py
+++ b/test/shared_setup.py
@@ -25,8 +25,6 @@
 #
 """Test shared_setup"""
 
-from __future__ import print_function
-
 import os
 import re
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 [tox]
-envlist = py27,py36
+envlist = py36
 skipsdist = true
 
 [testenv]

--- a/vsc-ci.ini
+++ b/vsc-ci.ini
@@ -2,3 +2,4 @@
 pip3_install_tox=1
 py3_tests_must_pass=1
 enable_github_actions=1
+py3_only=1


### PR DESCRIPTION
this is a first nudge in the direction of removing python2 support. it makes py3_only mandatory. it will try to give warnings and errors about python2, but I'm actually quite sure it just won't work.
Should not be merged before all known packages have been migrated.