### PR TITLE
more general cleanup

### DIFF
--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -34,7 +34,6 @@ Running python setup.py test will pick this up and do its magic
 @author: Stijn De Weirdt (Ghent University)
 """
 
-import optparse
 import os
 import pkg_resources
 import pprint
@@ -146,7 +145,6 @@ def prospector_ignore_paths_add(path):
 
 def run_prospector(base_dir, clear_ignore_patterns=False):
     """Run prospector and apply white/blacklists to the results"""
-    orig_expand_default = optparse.HelpFormatter.expand_default
 
     log.info("Using prosector version %s", prospector_version)
 
@@ -206,12 +204,6 @@ def run_prospector(base_dir, clear_ignore_patterns=False):
 
         if any([bool(reg.search(msg.code) or reg.search(msg.message)) for reg in whitelist]):
             failures.append(msg.as_dict())
-
-    # There is some ugly monkeypatch code in pylint
-    #     (or logilab if no recent enough pylint is installed)
-    # Make sure the original is restored
-    # (before any errors are reported; no need to put this in setUp/tearDown)
-    optparse.HelpFormatter.expand_default = orig_expand_default
 
     return failures
 

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -97,8 +97,7 @@ PROSPECTOR_WHITELIST = [
     'old-ne-operator',  # don't use <> as not equal operator, use !=
     'old-octal-literal',  # use 0o700 instead of 0700
     'old-raise-syntax',  # sed when the alternate raise syntax raise foo, bar is used instead of raise foo(bar) .
-    'print-statement',  # use print() and from future import __print__ instead of print
-    'raising-string',  # don't raise strings, raise objects extending Exception (python2)
+    'print-statement',  # use print()
     'raising-bad-type',  # don't raise strings, raise objects extending Exception (python3)
     'redefine-in-handler',  # except A, B -> except (A, B)
     'redefined-builtin',

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -166,7 +166,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.18.0'
+VERSION = '0.18.1'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -91,7 +91,8 @@ if not hasattr(__builtin__, '__test_filter'):
 # Keep this for legacy reasons, setuptools didn't used to be a requirement
 has_setuptools = True
 
-# redo log info / warn / error
+# redo log info / warn / error so it shows loglevel in log message
+# setuptools log does not support formatters
 # don't do it twice
 if log.Log.__name__ != 'NewLog':
     # make a map between level and names

--- a/lib/vsc/install/testing.py
+++ b/lib/vsc/install/testing.py
@@ -38,11 +38,7 @@ import re
 import shutil
 import sys
 import tempfile
-
-try:
-    from cStringIO import StringIO  # Python 2
-except ImportError:
-    from io import StringIO  # Python 3
+from io import StringIO
 
 from copy import deepcopy
 from unittest import TestCase as OrigTestCase
@@ -61,13 +57,6 @@ class TestCase(OrigTestCase):
     ASSERT_MAX_DIFF = 100
     DIFF_OFFSET = 5 # lines of text around changes
 
-    def is_string(self, x):
-        """test if the variable x is a string)"""
-        try:
-            return isinstance(x, basestring)
-        except NameError:
-            return isinstance(x, str)
-
     # pylint: disable=arguments-differ
     def assertEqual(self, a, b, msg=None):
         """Make assertEqual always print useful messages"""
@@ -80,11 +69,11 @@ class TestCase(OrigTestCase):
             else:
                 msg = "%s: %s" % (msg, e)
 
-            if self.is_string(a):
+            if isinstance(a, str):
                 txta = a
             else:
                 txta = pprint.pformat(a)
-            if self.is_string(b):
+            if isinstance(b, str):
                 txtb = b
             else:
                 txtb = pprint.pformat(b)
@@ -146,7 +135,7 @@ class TestCase(OrigTestCase):
             self.assertTrue(False, "Expected errors with %s(%s) call should occur" % (call.__name__, str_args))
         except error as err:
             msg = self.convert_exception_to_str(err)
-            if self.is_string(regex):
+            if isinstance(regex, str):
                 regex = re.compile(regex)
             self.assertTrue(regex.search(msg), "Pattern '%s' is found in '%s'" % (regex.pattern, msg))
 

--- a/test/ci.py
+++ b/test/ci.py
@@ -176,8 +176,6 @@ class CITest(TestCase):
             'pip_install_test_deps': None,
             'pip_install_tox': False,
             'pip3_install_tox': False,
-            'py3_only': True,
-            'py3_tests_must_pass': True,
             'run_shellcheck': False,
         }
 

--- a/vsc-ci.ini
+++ b/vsc-ci.ini
@@ -1,5 +1,3 @@
 [vsc-ci]
 pip3_install_tox=1
-py3_tests_must_pass=1
 enable_github_actions=1
-py3_only=1


### PR DESCRIPTION
 - remove old hack which depends on deprecated optparse
 - remove some more python 2 related dependency handling
 - explain distutils.log usage a bit better
 - get rid of `is_string()` function
 - deprecate and ignore py3_only and py3_tests options, so they are no longer mandatory, and can safely be removed
