### PR TITLE
make pip3 default over easy_install

### DIFF
--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -55,6 +55,7 @@ MOVE_SETUP_CFG = 'move_setup_cfg'
 PIP_INSTALL_TEST_DEPS = 'pip_install_test_deps'
 PIP_INSTALL_TOX = 'pip_install_tox'
 PIP3_INSTALL_TOX = 'pip3_install_tox'
+EASY_INSTALL_TOX = 'easy_install_tox'
 PY3_ONLY = 'py3_only'
 PY3_TESTS_MUST_PASS = 'py3_tests_must_pass'
 RUN_SHELLCHECK = 'run_shellcheck'
@@ -215,12 +216,12 @@ def parse_vsc_ci_cfg():
         JIRA_ISSUE_ID_IN_PR_TITLE: False,
         MOVE_SETUP_CFG: False,
         PIP_INSTALL_TEST_DEPS: None,
-        PIP3_INSTALL_TOX: False,
+        EASY_INSTALL_TOX: False,
         RUN_SHELLCHECK: False,
         ENABLE_GITHUB_ACTIONS: False,
     }
 
-    deprecated_options = [PY3_ONLY, PY3_TESTS_MUST_PASS, PIP_INSTALL_TOX]
+    deprecated_options = [PY3_ONLY, PY3_TESTS_MUST_PASS, PIP_INSTALL_TOX, PIP3_INSTALL_TOX]
 
     if os.path.exists(VSC_CI_INI):
         try:
@@ -277,14 +278,14 @@ def gen_jenkinsfile():
 
     python_cmd = 'python3'
 
-    if vsc_ci_cfg[PIP3_INSTALL_TOX]:
-        pip_args += '--ignore-installed --prefix %s' % prefix
-        test_cmds.append('%s %s tox' % (install_cmd, pip_args))
-
-    else:
+    if vsc_ci_cfg[EASY_INSTALL_TOX]:
         install_cmd = install_cmd.replace('pip3 install', 'python -m easy_install')
         easy_install_args += '-U --user'
         test_cmds.append('%s %s tox' % (install_cmd, easy_install_args))
+
+    else:
+        pip_args += '--ignore-installed --prefix %s' % prefix
+        test_cmds.append('%s %s tox' % (install_cmd, pip_args))
 
     # Python version to use for updating $PYTHONPATH must be determined dynamically, so use $(...) trick;
     # we must stick to just double strings in the command used to determine the Python version, to avoid

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -166,7 +166,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.18.2'
+VERSION = '0.18.3'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/vsc-ci.ini
+++ b/vsc-ci.ini
@@ -1,3 +1,2 @@
 [vsc-ci]
-pip3_install_tox=1
 enable_github_actions=1


### PR DESCRIPTION
as easy_install is deprecated, it should no longer be default. I find all projects have `pip3_install_tox` set to `True`. 
This change makes it most basic projects can just delete `vsc-ci.ini`.

added an option to still support the old `easy_install` way if for some reason it is still needed somewhere.
