### PR TITLE
Fix error in case of installing with pip and pyproject.toml

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -101,6 +101,7 @@ if log.Log.__name__ != 'NewLog':
     OrigLog = log.Log
 
     class NewLog(OrigLog):
+        """Logging class to prefix the message with a human readable log level"""
 
         def __init__(self, *args, **kwargs):
             self._orig_log = OrigLog._log
@@ -166,7 +167,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.18.4'
+VERSION = '0.18.5'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))


### PR DESCRIPTION
This cause an error in github pipelines. The logger class needs to have
a doc string...

See https://github.com/wpoely86/vsc-accountpage/actions/runs/4821249134/jobs/8586871529



