### PR TITLE
pin versions of virtualenv and tox compatible with Python v3.6

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -12,7 +12,6 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: install tox
-      # cap versions still compatible with Python 3.6
       run: pip install 'virtualenv<20.22.0' 'tox<4.5.0'
     - name: add mandatory git remote
       run: git remote add hpcugent https://github.com/hpcugent/vsc-install.git

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -12,7 +12,8 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: install tox
-      run: pip install tox
+      # cap versions still compatible with Python 3.6
+      run: pip install 'virtualenv<20.22.0' 'tox<4.5.0'
     - name: add mandatory git remote
       run: git remote add hpcugent https://github.com/hpcugent/vsc-install.git
     - name: Run tox

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -109,7 +109,8 @@ def gen_github_action(repo_base_dir=os.getcwd()):
                         {'name': 'Checkout code', 'uses': 'actions/checkout@v3'},
                         {'name': 'Setup Python', 'uses': 'actions/setup-python@v4',
                          'with': {'python-version': '${{ matrix.python }}'}},
-                        {'name': 'install tox', 'run': 'pip install tox'},
+                        # cap versions still compatible with Python 3.6
+                        {'name': 'install tox', 'run': "pip install 'virtualenv<20.22.0' 'tox<4.5.0'"},
                         {'name': 'add mandatory git remote',
                          'run': f'git remote add hpcugent {name_url}.git'},
                         {'name': 'Run tox', 'run': 'tox -e py'}

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -167,7 +167,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.18.5'
+VERSION = '0.18.6'
 
 log.info('This is (based on) vsc.install.shared_setup %s' % VERSION)
 log.info('(using setuptools version %s located at %s)' % (setuptools.__version__, setuptools.__file__))

--- a/test/ci.py
+++ b/test/ci.py
@@ -123,7 +123,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: install tox
-      run: pip install tox
+      run: pip install 'virtualenv<20.22.0' 'tox<4.5.0'
     - name: add mandatory git remote
       run: git remote add hpcugent https://github.com/hpcugent/vsc-install.git
     - name: Run tox


### PR DESCRIPTION
We hit issue https://github.com/pypa/virtualenv/issues/2550 due to changes from https://github.com/pypa/virtualenv/pull/2548 . This means that all tests in Python 3.6 fail with latest versions of `tox` and `virtualenv`.

This PR caps the versions to those still compatible with Python 3.6.