### PR TITLE
add a workable test stack for python 3.9

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1499,23 +1499,18 @@ class vsc_setup():
                 'isort < 5.11.0',
                 'zipp < 3.16', # no longer compatible with python 3.6
             ])
-        elif sys.version_info < (3, 10):
+
+        # tested for python 3.9
+        # currently prospector is the failing factor
+        # it does not support newest pylint and it's plugins yet
+        else:
             tests_requires.extend([
-                'pyflakes~=2.3.0',
-                'pycodestyle~=2.7.0',
-                'pylint~=2.12.2',
-                'prospector~=1.5.3.1',
-                'flake8~=3.9.2',
-                'pylint-plugin-utils < 0.7',
-                'pylint-django~=2.4.4',
-            ])
-        else:  # tested for fedora37 py3.11
-            tests_requires.extend([
-                'flake8 < 5.0.0',
-                'astroid <= 2.12.0-dev0',
-                'pyflakes < 2.5.0',
-                'pylint~=2.14.4',
-                'prospector~=1.7.7',
+                'pylint < 3',
+                'prospector',
+                'pylint-plugin-utils < 0.8',
+                'pylint-django < 2.5.4',
+                'astroid <= 2.17.0-dev0',
+                'pycodestyle < 2.10'
             ])
 
         new_target['tests_require'] = tests_requires

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -168,7 +168,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.18.10'
+VERSION = '0.18.11'
 
 log.info('This is (based on) vsc.install.shared_setup %s', VERSION)
 log.info('(using setuptools version %s located at %s)', setuptools.__version__, setuptools.__file__)
@@ -1498,6 +1498,16 @@ class vsc_setup():
                 'importlib-metadata < 5.0.0', # no longer compatible with python 3.7
                 'isort < 5.11.0',
                 'zipp < 3.16', # no longer compatible with python 3.6
+            ])
+        elif sys.version_info < (3, 10):
+            tests_requires.extend([
+                'pyflakes~=2.3.0',
+                'pycodestyle~=2.7.0',
+                'pylint~=2.12.2',
+                'prospector~=1.5.3.1',
+                'flake8~=3.9.2',
+                'pylint-plugin-utils < 0.7',
+                'pylint-django~=2.4.4',
             ])
         else:  # tested for fedora37 py3.11
             tests_requires.extend([


### PR DESCRIPTION
this works. I'll make an attempt at making the versions a bit newer, but it's dependency hell between prospector and pylint-django.

whoever said it tested and worked on py3.11 was surely wrong. (probably me)