### PR TITLE
run python 3.9 tests by default, ignore outcome unless specified

### DIFF
--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -58,6 +58,7 @@ PIP3_INSTALL_TOX = 'pip3_install_tox'
 EASY_INSTALL_TOX = 'easy_install_tox'
 PY3_ONLY = 'py3_only'
 PY3_TESTS_MUST_PASS = 'py3_tests_must_pass'
+PY39_TESTS_MUST_PASS = 'py39_tests_must_pass'
 RUN_SHELLCHECK = 'run_shellcheck'
 ENABLE_GITHUB_ACTIONS = 'enable_github_actions'
 
@@ -145,9 +146,9 @@ def gen_tox_ini():
     # list of Python environments in which tests should be run
     envs = []
 
-    # always run tests with Python 3
-    py3_env = 'py36'
-    envs.append(py3_env)
+    # always run tests with Python 3.6 and 3.9
+    py3_envs = ['py36', 'py39']
+    envs.extend(py3_envs)
 
     pip_args, easy_install_args = '', ''
     if vsc_ci_cfg[INSTALL_SCRIPTS_PREFIX_OVERRIDE]:
@@ -162,6 +163,13 @@ def gen_tox_ini():
         # (setup.py requires vsc-install, which is not installed yet when 'python setup.py sdist' is run)
         "skipsdist = true",
     ]
+
+    if not vsc_ci_cfg[PY39_TESTS_MUST_PASS]:
+        lines.extend([
+            '',
+            '[testenv:py39]',
+            'ignore_outcome = true'
+        ])
 
     lines.extend([
         '',
@@ -220,6 +228,7 @@ def parse_vsc_ci_cfg():
         EASY_INSTALL_TOX: False,
         RUN_SHELLCHECK: False,
         ENABLE_GITHUB_ACTIONS: False,
+        PY39_TESTS_MUST_PASS: False,
     }
 
     deprecated_options = [PY3_ONLY, PY3_TESTS_MUST_PASS, PIP_INSTALL_TOX, PIP3_INSTALL_TOX]

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -295,7 +295,7 @@ if hasattr(setuptools.dist.Distribution, 'get_egg_cache_dir'):
 
         # the original get_egg_cache_dir creates the .eggs directory if it doesn't exist yet,
         # but we want to have it versioned, so we rename it
-        egg_cache_dir_pyver = f'{egg_cache_dir}.py{sys.version_info[0]}'
+        egg_cache_dir_pyver = f'{egg_cache_dir}.py{sys.version_info[0]}{sys.version_info[1]}'
         try:
             if not os.path.exists(egg_cache_dir_pyver):
                 os.rename(egg_cache_dir, egg_cache_dir_pyver)

--- a/test/ci.py
+++ b/test/ci.py
@@ -93,8 +93,11 @@ EXPECTED_TOX_INI = """# tox.ini: configuration file for tox
 # DO NOT EDIT MANUALLY
 
 [tox]
-envlist = py36
+envlist = py36,py39
 skipsdist = true
+
+[testenv:py39]
+ignore_outcome = true
 
 [testenv]
 commands_pre =
@@ -104,9 +107,20 @@ commands = python setup.py test
 passenv = USER
 """
 
-EXPECTED_TOX_INI_PY36_IGNORE = """
-[testenv:py36]
-ignore_outcome = true
+EXPECTED_TOX_INI_WITH_PY39 = """# tox.ini: configuration file for tox
+# This file was automatically generated using 'python -m vsc.install.ci'
+# DO NOT EDIT MANUALLY
+
+[tox]
+envlist = py36,py39
+skipsdist = true
+
+[testenv]
+commands_pre =
+    pip install 'setuptools<42.0'
+    python -m easy_install -U vsc-install
+commands = python setup.py test
+passenv = USER
 """
 
 EXPECTED_GITHUB_ACTIONS = """# .github/workflows/unittest.yml: configuration file for github actions worflow
@@ -171,6 +185,7 @@ class CITest(TestCase):
             'pip_install_test_deps': None,
             'easy_install_tox': False,
             'run_shellcheck': False,
+            'py39_tests_must_pass': False,
         }
 
         # (basically) empty vsc-ci.ini
@@ -275,6 +290,11 @@ class CITest(TestCase):
     def test_tox_ini(self):
         """Test generating of tox.ini."""
         self.assertEqual(gen_tox_ini(), EXPECTED_TOX_INI)
+
+    def test_tox_ini_py39_must_pass(self):
+        """test that py39 tests must pass"""
+        self.write_vsc_ci_ini('py39_tests_must_pass=1')
+        self.assertEqual(gen_tox_ini(), EXPECTED_TOX_INI_WITH_PY39)
 
     def test_tox_ini_inherit_site_packages(self):
         """Test generation of tox.ini with inheriting of site packages enabled."""

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,11 @@
 # DO NOT EDIT MANUALLY
 
 [tox]
-envlist = py36
+envlist = py36,py39
 skipsdist = true
+
+[testenv:py39]
+ignore_outcome = true
 
 [testenv]
 commands_pre =


### PR DESCRIPTION
if `py39_tests_must_pass=1` is set in vsc-ci.ini tests will have to pass.

still running into the prospector bug though. (https://github.com/landscapeio/prospector/issues/527) it should have been fixed, so investigating. (maybe it was reintroduced)