### PR TITLE
enable more pylint

### DIFF
--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -84,6 +84,7 @@ PROSPECTOR_WHITELIST = [
     'bad-whitespace',
     'bare-except',
     'consider-using-dict-comprehension',
+    'consider-using-f-string',
     'consider-using-set-comprehension',
     'consider-using-with', # By using 'with' the release of the allocated res is ensured in the case of an exception.
     'dangerous-default-value',
@@ -107,14 +108,18 @@ PROSPECTOR_WHITELIST = [
     'redefine-in-handler',  # except A, B -> except (A, B)
     'redefined-builtin',
     'reimported',
+    'super-with-arguments',
     'syntax-error',
     'trailing-whitespace',
     'undefined',
+    'unidiomatic-typecheck',
+    'unnecessary-pass',
     'unnecessary-semicolon',
     'unpacking-in-except', # will stop working in python3
     'unused-argument',
     'unused-import',
     'unused-variable',
+    'useless-object-inheritance',
 ]
 
 # Prospector commandline options (positional path is added automatically)

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -372,7 +372,7 @@ class vsc_setup():
 
         # multiline search
         # github pattern for hpcugent, not fork
-        git_remote_patterns = ['%s.*?[:/]%s' % remote for remote in GIT_REMOTES]
+        git_remote_patterns = [f'{remote}.*?[:/]{value}' for remote, value in GIT_REMOTES]
         git_domain_pattern = f"(?:{'|'.join(git_remote_patterns)})"
         all_patterns = {
             'name': [
@@ -406,7 +406,7 @@ class vsc_setup():
             self.private_repo = True
 
         if 'url' not in res:
-            allowed_remotes = ', '.join(['%s/%s' % remote for remote in GIT_REMOTES])
+            allowed_remotes = ', '.join([f'{remote}/{value}' for remote, value in GIT_REMOTES])
             raise KeyError(f"Missing url in git config {res}. (Missing mandatory remote? {allowed_remotes})")
 
         # handle git://server/user/project

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -166,7 +166,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.19.5'
+VERSION = '0.19.6'
 
 log.info('This is (based on) vsc.install.shared_setup %s', VERSION)
 log.info('(using setuptools version %s located at %s)', setuptools.__version__, setuptools.__file__)


### PR DESCRIPTION
These are the main pylint tests which flag "old school" coding style from before python 3.6.

 - I'm a bit hesitant to enable `consider-using-fstring` because it's a lot. I cleaned out a lot of projects already but still.
 - `super-with-arguments`: was for python 2
 - `useless-object-inheritance`: same, no need to add it anymore
 - `unidiomatic-typecheck`: use `isinstance(var, type)` instead of `if type(var) == type`
 - `unnecessary-pass`: if an  empty function or class has a docstring, a `pass` is not needed.

This PR will fail it's own tests, needs https://github.com/hpcugent/vsc-install/pull/234

opinions?
