### PR TITLE
start to get rid of dist_utils

### DIFF
--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -241,7 +241,8 @@ def run_prospector(base_dir, clear_ignore_patterns=False):
     #     (or logilab if no recent enough pylint is installed)
     # Make sure the original is restored
     # (before any errors are reported; no need to put this in setUp/tearDown)
-    optparse.HelpFormatter.expand_default = orig_expand_default
+    if sys.version_info < (3,9):
+        optparse.HelpFormatter.expand_default = orig_expand_default
 
     return failures
 

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -48,7 +48,6 @@ import setuptools.dist
 import setuptools.command.test
 
 from distutils import log  # also for setuptools
-from distutils.dir_util import remove_tree
 
 from setuptools import Command
 from setuptools.command.test import test as TestCommand
@@ -1234,7 +1233,7 @@ class vsc_setup():
             if os.path.isdir(dirname):
                 log.warn("cleanup %s", dirname)
                 try:
-                    remove_tree(dirname, verbose=False)
+                    shutil.rmtree(dirname)
                 except OSError:
                     log.error("cleanup failed for %s", dirname)
 


### PR DESCRIPTION
we also import log from distutils. Reccomendations are to use plain logging instead. But the fix needed for that in setuptools is only in a recent setuptools which we lock at v42...

So I can't fix the logging until we more to a newer setuptools 