### PR TITLE
use correct tox environment name in GitHub Actions workflow

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -16,7 +16,7 @@ jobs:
     - name: add mandatory git remote
       run: git remote add hpcugent https://github.com/hpcugent/vsc-install.git
     - name: Run tox
-      run: tox -e py
+      run: tox -e py$(echo ${{ matrix.python }} | sed 's/\.//g')
     strategy:
       matrix:
         python:

--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 Ghent University
+# Copyright 2015-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/__init__.py
+++ b/lib/vsc/install/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 Ghent University
+# Copyright 2015-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -119,7 +119,7 @@ def gen_github_action(repo_base_dir=os.getcwd()):
                         {'name': 'install tox', 'run': "pip install 'virtualenv<20.22.0' 'tox<4.5.0'"},
                         {'name': 'add mandatory git remote',
                          'run': f'git remote add hpcugent {name_url}.git'},
-                        {'name': 'Run tox', 'run': 'tox -e py'}
+                        {'name': 'Run tox', 'run': "tox -e py$(echo ${{ matrix.python }} | sed 's/\.//g')"}
                     ]
                 }
             }

--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/commontest.py
+++ b/lib/vsc/install/commontest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2023 Ghent University
+# Copyright 2014-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/headers.py
+++ b/lib/vsc/install/headers.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 Ghent University
+# Copyright 2015-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2023 Ghent University
+# Copyright 2011-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -189,7 +189,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.20.0'
+VERSION = '0.20.1'
 
 log.info('This is (based on) vsc.install.shared_setup %s', VERSION)
 log.info('(using setuptools version %s located at %s)', setuptools.__version__, setuptools.__file__)

--- a/lib/vsc/install/testing.py
+++ b/lib/vsc/install/testing.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2023 Ghent University
+# Copyright 2014-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Ghent University
+# Copyright 2016-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Ghent University
+# Copyright 2016-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/ci.py
+++ b/test/ci.py
@@ -181,7 +181,7 @@ jobs:
     - name: add mandatory git remote
       run: git remote add hpcugent https://github.com/hpcugent/vsc-install.git
     - name: Run tox
-      run: tox -e py
+      run: tox -e py$(echo ${{ matrix.python }} | sed 's/\.//g')
     strategy:
       matrix:
         python:

--- a/test/ci.py
+++ b/test/ci.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/commontest.py
+++ b/test/commontest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/headers.py
+++ b/test/headers.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Ghent University
+# Copyright 2016-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/licenses.py
+++ b/test/licenses.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Ghent University
+# Copyright 2016-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest.py
+++ b/test/prospectortest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Ghent University
+# Copyright 2016-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/__init__.py
+++ b/test/prospectortest/lib/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/E101.py
+++ b/test/prospectortest/lib/vsc/mockinstall/E101.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/E111.py
+++ b/test/prospectortest/lib/vsc/mockinstall/E111.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/E501.py
+++ b/test/prospectortest/lib/vsc/mockinstall/E501.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/E713.py
+++ b/test/prospectortest/lib/vsc/mockinstall/E713.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/F811.py
+++ b/test/prospectortest/lib/vsc/mockinstall/F811.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/W291.py
+++ b/test/prospectortest/lib/vsc/mockinstall/W291.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/__init__.py
+++ b/test/prospectortest/lib/vsc/mockinstall/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/arguments_differ.py
+++ b/test/prospectortest/lib/vsc/mockinstall/arguments_differ.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/backtick.py
+++ b/test/prospectortest/lib/vsc/mockinstall/backtick.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/bad_indentation.py
+++ b/test/prospectortest/lib/vsc/mockinstall/bad_indentation.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/bare_except.py
+++ b/test/prospectortest/lib/vsc/mockinstall/bare_except.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/dangerous_default_value.py
+++ b/test/prospectortest/lib/vsc/mockinstall/dangerous_default_value.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/duplicate_key.py
+++ b/test/prospectortest/lib/vsc/mockinstall/duplicate_key.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/import_star_module_level.py
+++ b/test/prospectortest/lib/vsc/mockinstall/import_star_module_level.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/indexing_exception.py
+++ b/test/prospectortest/lib/vsc/mockinstall/indexing_exception.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/line_too_long.py
+++ b/test/prospectortest/lib/vsc/mockinstall/line_too_long.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/metaclass_assignment.py
+++ b/test/prospectortest/lib/vsc/mockinstall/metaclass_assignment.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/no_value_for_parameter.py
+++ b/test/prospectortest/lib/vsc/mockinstall/no_value_for_parameter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/old_ne_operator.py
+++ b/test/prospectortest/lib/vsc/mockinstall/old_ne_operator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/old_octal_literal.py
+++ b/test/prospectortest/lib/vsc/mockinstall/old_octal_literal.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/old_raise_syntax.py
+++ b/test/prospectortest/lib/vsc/mockinstall/old_raise_syntax.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/print_statement.py
+++ b/test/prospectortest/lib/vsc/mockinstall/print_statement.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/raising_bad_type.py
+++ b/test/prospectortest/lib/vsc/mockinstall/raising_bad_type.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/raising_string.py
+++ b/test/prospectortest/lib/vsc/mockinstall/raising_string.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/redefine_in_handler.py
+++ b/test/prospectortest/lib/vsc/mockinstall/redefine_in_handler.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/redefined_builtin.py
+++ b/test/prospectortest/lib/vsc/mockinstall/redefined_builtin.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/reimported.py
+++ b/test/prospectortest/lib/vsc/mockinstall/reimported.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/syntax_error.py
+++ b/test/prospectortest/lib/vsc/mockinstall/syntax_error.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/trailing_whitespace.py
+++ b/test/prospectortest/lib/vsc/mockinstall/trailing_whitespace.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/undefined_variable.py
+++ b/test/prospectortest/lib/vsc/mockinstall/undefined_variable.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/unpacking_in_except.py
+++ b/test/prospectortest/lib/vsc/mockinstall/unpacking_in_except.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/unused_argument.py
+++ b/test/prospectortest/lib/vsc/mockinstall/unused_argument.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/unused_import.py
+++ b/test/prospectortest/lib/vsc/mockinstall/unused_import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/prospectortest/lib/vsc/mockinstall/unused_variable.py
+++ b/test/prospectortest/lib/vsc/mockinstall/unused_variable.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2023 Ghent University
+# Copyright 2023-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/shared_setup.py
+++ b/test/shared_setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Ghent University
+# Copyright 2016-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/testdata/vsc/__init__.py
+++ b/test/testdata/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 Ghent University
+# Copyright 2015-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/testdata/vsc/test/__init__.py
+++ b/test/testdata/vsc/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 Ghent University
+# Copyright 2015-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/testing.py
+++ b/test/testing.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2023 Ghent University
+# Copyright 2012-2024 Ghent University
 #
 # This file is part of vsc-install,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),


### PR DESCRIPTION
We should use `tox -e py36` and `tox -e py39` instead of just `tox -e py`, to make sure that customizations for specific environment as being done in https://github.com/hpcugent/vsc-base/pull/351 work correctly

cc @stdweird 