### PR TITLE
python 3.9 tests must pass by default

### DIFF
--- a/lib/vsc/install/ci.py
+++ b/lib/vsc/install/ci.py
@@ -256,7 +256,7 @@ def parse_vsc_ci_cfg():
         RUN_SHELLCHECK: False,
         ENABLE_GITHUB_ACTIONS: False,
         PY36_TESTS_MUST_PASS: True,
-        PY39_TESTS_MUST_PASS: False,
+        PY39_TESTS_MUST_PASS: True,
     }
 
     deprecated_options = [PY3_ONLY, PY3_TESTS_MUST_PASS, PIP_INSTALL_TOX, PIP3_INSTALL_TOX]

--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -189,7 +189,7 @@ URL_GHUGENT_HPCUGENT = 'https://github.ugent.be/hpcugent/%(name)s'
 
 RELOAD_VSC_MODS = False
 
-VERSION = '0.21.1'
+VERSION = '0.21.2'
 
 log.info('This is (based on) vsc.install.shared_setup %s', VERSION)
 log.info('(using setuptools version %s located at %s)', setuptools.__version__, setuptools.__file__)

--- a/test/ci.py
+++ b/test/ci.py
@@ -103,7 +103,6 @@ commands_pre =
     python -m easy_install -U vsc-install
 
 [testenv:py39]
-ignore_outcome = true
 setenv = SETUPTOOLS_USE_DISTUTILS=local
 commands_pre =
     pip install 'setuptools<54.0' wheel
@@ -222,7 +221,7 @@ class CITest(TestCase):
             'easy_install_tox': False,
             'run_shellcheck': False,
             'py36_tests_must_pass': True,
-            'py39_tests_must_pass': False,
+            'py39_tests_must_pass': True,
         }
 
         # (basically) empty vsc-ci.ini


### PR DESCRIPTION
we don't notice this because we have set it to true in all `vsc-ci.ini` files. but it really should be default.